### PR TITLE
Updating the timestamp to a more condenced format.

### DIFF
--- a/gubernator.sh
+++ b/gubernator.sh
@@ -98,8 +98,8 @@ end_line=$(grep JUJU_E2E_END ${BUILD_LOG_PATH})
 end_time_epoch=$(echo $end_line | cut -d = -f 2)
 end_time=$(date -d @${end_time_epoch} '+%m/%d %H:%M:%S.000')
 
-# Make folder name for build from timestamp
-BUILD_STAMP=$(echo $start_time | sed 's/\///' | sed 's/ /_/')
+# Create a folder safe name for build timestamp
+BUILD_STAMP=$(date -d @${start_time_epoch} '+%m%d%H%M%S000')
 
 GCS_LOGS_PATH="${GCS_JOBS_PATH}/${BUILD_STAMP}"
 


### PR DESCRIPTION
Resolves https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/147

We need to land these changes before our automated system can build with this patch, unless I change the job to accept branches, which I can do that is fine.