### PR TITLE
Splitting out common parts to reusable files.

### DIFF
--- a/define-juju.sh
+++ b/define-juju.sh
@@ -1,0 +1,35 @@
+# Define common Juju functions such as jujubox and charmbox.
+
+
+# A function to run a command in the charmbox container.
+function in-charmbox() {
+  docker run \
+    --rm \
+    -v ${JUJU_DATA}:/home/ubuntu/.local/share/juju \
+    -v ${WORKSPACE}:/home/ubuntu/workspace \
+    --entrypoint /bin/bash \
+    jujusolutions/charmbox:latest \
+    -c "$@"
+}
+
+# A function to make charm commands run inside a container.
+function charm() {
+  in-charmbox charm $@
+}
+
+# A function to run a command in the jujubox container.
+function in-jujubox() {
+  docker run \
+    --rm \
+    -v ${JUJU_DATA}:/home/ubuntu/.local/share/juju \
+    -v ${WORKSPACE}:/home/ubuntu/workspace \
+    --entrypoint /bin/bash \
+    jujusolutions/jujubox:latest \
+    -c "$@"
+}
+
+# A function to make juju commands run inside a container.
+function juju() {
+  # Call the function that runs the commands in a jujubox container.
+  in-jujubox juju $@
+}

--- a/gubernator.sh
+++ b/gubernator.sh
@@ -10,7 +10,7 @@ set -o xtrace  # Print the commands that are executed.
 echo "${0} started at `date`."
 
 # The location of the artifacts from the e2e run that are to be uploaded.
-export ARTIFACTS=${WORKSPACE}/artifacts
+export ARTIFACTS=${1:-"artifacts"}
 
 # Use a docker container for the gcloud commands.
 function gcloud {

--- a/jenkins-all-builder.sh
+++ b/jenkins-all-builder.sh
@@ -9,8 +9,6 @@ echo "${0} started at `date`."
 
 SCRIPT_DIR=${PWD}
 
-source ./util.sh
-
 # The version is the first optional argument.
 VERSION=${1:-"v1.5.0"}
 # The URL is the second optional argument.
@@ -73,6 +71,9 @@ TARGETS='cmd/kube-dns \
 ${BUILD_DIR}/run.sh make all WHAT="${TARGETS}"
 
 echo "Build finished `date`"
+
+# Get the function definitions for os and architecture detection.
+source ./utilities.sh
 
 OS=$(get_os)
 ARCH=$(get_arch)

--- a/jenkins-cross-builder.sh
+++ b/jenkins-cross-builder.sh
@@ -9,8 +9,6 @@ echo "${0} started at `date`."
 
 SCRIPT_DIR=${PWD}
 
-source ./util.sh
-
 # The version is the first optional argument.
 VERSION=${1:-"v1.5.0"}
 # The URL is the second optional argument.
@@ -74,8 +72,12 @@ ${BUILD_DIR}/run.sh make cross WHAT="${TARGETS}"
 
 echo "Build finished `date`"
 
+# Get the function definitions for os detection and create_archive.
+source ./utilities.sh
+
 OS=$(get_os)
 ARCHITECTURES="amd64 arm64 ppc64le s390x"
+
 # Iterate over the supported architectures.
 for ARCH in ${ARCHITECTURES}; do
   OUTPUT_DIRECTORY=${KUBE_ROOT}/_output/dockerized/bin/${OS}/${ARCH}

--- a/jenkins-e2e.sh
+++ b/jenkins-e2e.sh
@@ -14,8 +14,21 @@ tar -xvzf ${JUJU_DATA_TAR} -C ${WORKSPACE}
 # Set the JUJU_DATA directory for this jenkins workspace.
 export JUJU_DATA=${WORKSPACE}/juju
 
-# Deploy a Kubernetes cluster and the e2e charm, and run the test action.
-./e2e-runner.sh
+# Define a unique model name for this run.
+MODEL=${BULD_TAG}
+# Set the output directory to store the results.
+OUTPUT_DIRECTORY=artifacts
+# Set the bundle name to use.
+BUNDLE=kubernetes-core
 
-# Formats the data and upload to GCE.
-./gubernator.sh
+# Deploy the bundle and add the kubernetes-e2e charm.
+./juju-deploy-test-bundle.sh ${MODEL} ${BUNDLE}
+
+# Let the deployment complete.
+./wait-cluster-ready.sh
+
+# Run the end to end tests and 
+./run-e2e-tests.sh ${OUTPUT_DIRECTORY}
+
+# Formats the output data and upload to GCE.
+./gubernator.sh ${OUTPUT_DIRECTORY}

--- a/jenkins-fresh-resources.sh
+++ b/jenkins-fresh-resources.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Deploys the test bundle, attaches resources, and runs bundletester.
+
+set -o errexit  # Exit when an individual command fails.
+set -o pipefail  # The exit status of the last command is returned.
+set -o xtrace  # Print the commands that are executed.
+
+# Define a unique model name for this run.
+MODEL=${1:-${BUILD_TAG}}
+# Set the bundle to deploy.
+BUNDLE=${2:-"kubernetes-core"}
+# Set the directory to find the resources in.
+RESOURCES_DIRECTORY=${3:-"resources"}
+# Set the directory to save the output.
+OUTPUT_DIRECTORY=${4:"artifacts/bundletester"}
+
+# Deploy the bundle and add the kubernetes-e2e charm.
+./juju-deploy-test-bundle.sh ${MODEL} ${BUNDLE}
+
+# Run a fresh deploy with resources copied from another jenkins job.
+./juju-attach-resources.sh ${RESOURCES_DIRECTORY}
+
+# Let the deployment complete.
+./wait-cluster-ready.sh
+
+# Run bundletester against the model.
+./run-bundletester.sh ${BUNDLE} ${OUTPUT_DIRECTORY}
+
+# According to the design bundletester results verify new resources.
+# The e2e tests can be run in a non blocking downstream job.
+
+# TODO Remember to destroy the model when done.

--- a/juju-attach-resources.sh
+++ b/juju-attach-resources.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Attaches local resources to Kubernetes charms.
+
+set -o errexit  # Exit when an individual command fails.
+set -o pipefail  # The exit status of the last command is returned.
+set -o xtrace  # Print the commands that are executed.
+
+echo "${0} started at `date`."
+
+# The first argument is the _relative_ resources directory.
+RESOURCES_DIRECTORY=${1:-"resources"}
+
+# Define the functions that return the architecture.
+source ./utilities.sh
+ARCH=$(get_arch)
+
+# Get the _relative_ resource names.
+MASTER_RESOURCE=$(ls -1 ${RESOURCES_DIRECTORY}/kubernetes-master-*-${ARCH}.tar.gz)
+WORKER_RESOURCE=$(ls -1 ${RESOURCES_DIRECTORY}/kubernetes-worker-*-${ARCH}.tar.gz)
+E2E_RESOURCE=$(ls -1 ${RESOURCES_DIRECTORY}/e2e-*-${ARCH}.tar.gz)
+
+# Define the juju functions.
+source ./define-juju.sh
+
+# Attach the resources using the workspace directory inside the container.
+juju attach kubernetes-master kubernetes=/home/ubuntu/workspace/${MASTER_RESOURCE}
+juju attach kubernetes-worker kubernetes=/home/ubuntu/workspace/${WORKER_RESOURCE}
+juju attach kubernetes-e2e e2e_${ARCH}=/home/ubuntu/workspace/${E2E_RESOURCE}
+
+echo "${0} completed successfully at `date`."

--- a/juju-deploy-test-bundle.sh
+++ b/juju-deploy-test-bundle.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Deploys a kubernetes bundle, and the kubernetes-e2e charm adding relations.
+
+set -o errexit  # Exit when an individual command fails.
+set -o pipefail  # The exit status of the last command is returned.
+set -o xtrace  # Print the commands that are executed.
+
+echo "${0} started at `date`."
+
+# First argument is the model namme for this build.
+MODEL=${1:-"model-is-undefined"}
+# The second argument is the bundle name.
+BUNDLE=${2:-"kubernetes-core"}
+# Some of the files in JUJU_DATA my not be owned by the ubuntu user, fix that.
+CHOWN_CMD="sudo chown -R ubuntu:ubuntu /home/ubuntu/.local/share/juju"
+# Define the juju and in-jujubox functions.
+source ./define-juju.sh
+# Create a model just for this run of the tests.
+in-jujubox "${CHOWN_CMD} && juju add-model ${MODEL}"
+
+# Set test mode on the deployment so we dont bloat charm-store deployment count
+juju model-config -m ${MODEL} test-mode=1
+
+# Deploy the kubernetes bundle.
+juju deploy ${BUNDLE}
+# TODO Check for a second worker, the bundle could already define one.
+# Add one more kubernetes node to the cluster.
+juju add-unit kubernetes-worker
+# TODO Check for the e2e charm, the bundle could already define one.
+# Deploy the e2e charm and make the relations.
+juju deploy cs:~containers/kubernetes-e2e
+juju relate kubernetes-e2e kubernetes-master
+juju relate kubernetes-e2e easyrsa
+
+# NOTE This script only deploys the bundle and charms, no waiting is done here!
+
+echo "${0} completed successfully at `date`."

--- a/local-e2e.sh
+++ b/local-e2e.sh
@@ -19,9 +19,13 @@ tar -xvzf ${JUJU_DATA_TAR} -C ${WORKSPACE}
 
 # Set the JUJU_DATA directory for this jenkins workspace.
 export JUJU_DATA=${WORKSPACE}/juju
+# Set the model to a unique name for this run.
+export MODEL=${BULD_TAG}
+# Set the output directory to store the results.
+export OUTPUT_DIRECTORY=${WORKSPACE}/artifacts
 
 # Deploy a Kubernetes cluster and the e2e charm, and run the test action.
-./e2e-runner.sh
+./e2e-runner.sh ${MODEL} ${OUTPUT_DIRECTORY}
 
 # Formats the data and upload to GCE.
-./gubernator.sh
+./gubernator.sh ${OUTPUT_DIRECTORY}

--- a/repackage-v1.4-resources.sh
+++ b/repackage-v1.4-resources.sh
@@ -8,8 +8,6 @@ set -o pipefail  # The exit status of the last command is returned.
 
 echo "${0} started at `date`."
 
-source ./util.sh
-
 SCRIPT_DIR=${PWD}
 
 # Create a temporary directory to hold the files.
@@ -38,6 +36,9 @@ if [[ ! -e "${KUBE_ROOT}/version" ]]; then
 fi
 VERSION=$(cat ${KUBE_ROOT}/version)
 echo "Found version: ${VERSION}"
+
+# Get the function definitions for os and architecture detection.
+source ./utilities.sh
 
 ARCH=$(get_arch)
 OS=$(get_os)

--- a/repackage-v1.5-resources.sh
+++ b/repackage-v1.5-resources.sh
@@ -8,8 +8,6 @@ set -o pipefail  # The exit status of the last command is returned.
 
 echo "${0} started at `date`."
 
-source ./util.sh
-
 SCRIPT_DIR=${PWD}
 
 # Create a temporary directory to hold the files.
@@ -43,10 +41,13 @@ export KUBERNETES_SKIP_CONFIRM=Y
 export KUBERNETES_DOWNLOAD_TESTS=Y
 # Use the upstream utility for downloading binaries.
 ${KUBE_ROOT}/cluster/get-kube-binaries.sh
-# This script does not download architectures other than the host system.
-# TODO figure out how to download different architectures.
+
+# Get the function definitions for os and architecture detection.
+source ./utilities.sh
+
 ARCH=$(get_arch)
 OS=$(get_os)
+# TODO figure out how to download different architectures for 1.5 structure.
 
 E2E_DIRECTORY=${KUBE_ROOT}/platforms/${OS}/${ARCH}
 E2E_ARCHIVE=${SCRIPT_DIR}/e2e-${VERSION}-${ARCH}.tar.gz

--- a/run-bundletester.sh
+++ b/run-bundletester.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Runs bundletester against the deployed bundle.
+
+set -o errexit  # Exit when an individual command fails.
+set -o pipefail  # The exit status of the last command is returned.
+set -o xtrace  # Print the commands that are executed.
+
+echo "${0} started at `date`."
+
+# The first argument is the bundle to test.
+BUNDLE=${1:-"kubernetes-core"}
+# The second argument is the relative path to the output directory.
+OUTPUT_DIRECTORY=${2:-"artifacts/bundletester"}
+
+# Create the output directory.
+mkdir -p ${OUTPUT_DIRECTORY}
+
+# Define the juju and charmbox functions.
+source ./define-juju.sh
+
+OUTPUT_FILE=${OUTPUT_DIRECTORY}/`date +%s`-results.txt
+
+# When the bundle starts with http it is a url, so download the raw file.
+if [[ ${BUNDLE} == "http"* ]]; then
+  # Create a relative directory so it is available in Docker under workspace.
+  mkdir -p bundle
+  BUNDLE_FILE=bundle/bundle.yaml
+  # Download the bundle, following redirects (-L) save to specific name.
+  curl -L ${BUNDLE} -o ${BUNDLE_FILE}
+  # The tests.yaml file configures this bundletester run.
+  TESTS_YAML=bundle/tests.yaml
+  # Create a tests.yaml file that does not reset the environment.
+  cat << EOF > ${TESTS_YAML}
+tests: "*"
+# Adding tims PPA so we get current dependencies
+sources:
+  - ppa:tvansteenburgh/ppa
+packages:
+  - amulet
+  - juju-deployer
+  - python-jujuclient
+reset: false
+EOF
+  # Create the command to test the downloaded bundle file with the tests.yaml.
+  TEST_CMD="bundletester -b workspace/${BUNDLE_FILE} -y workspace/${TEST_YAML} --no-destroy -l DEBUG -v 2>&1 | tee workspace/${OUTPUT_FILE}"
+  # Run the test command in charmbox.
+  in-charmbox "${TEST_CMD}"
+else
+  # Download the charm from the Charm Store to the workspace directory.
+  CHARM_PULL_CMD="charm pull ${BUNDLE} workspace/${BUNDLE}"
+  # The bundle file when downloaded from the 
+  BUNDLE_FILE=workspace/${BUNDLE}/bundle.yaml
+  TESTS_YAML=workspace/${BUNDLE}/tests/tests.yaml
+  # Create the command to test the Charm Store bundle with tests.yaml
+  TEST_CMD="bundletester -b ${BUNDLE_FILE} -y ${TESTS_YAML} --no-destroy -l DEBUG -v 2>&1 | tee workspace/${OUTPUT_FILE}"
+  # Run the charm pull and test commands in charmbox.
+  in-charmbox "${CHARM_PULL_CMD} && ${TEST_CMD}"
+fi
+
+echo "${0} completed successfully at `date`."

--- a/run-e2e-tests.sh
+++ b/run-e2e-tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run the test action on the kubernetes-e2e charm.
+
+set -o errexit  # Exit when an individual command fails.
+set -o pipefail  # The exit status of the last command is returned.
+set -o xtrace  # Print the commands that are executed.
+
+echo "${0} started at `date`."
+
+# The first argument is the output directory.
+OUTPUT_DIRECTORY=${1:-"artifacts"}
+
+# Create the output directory.
+mkdir -p ${OUTPUT_DIRECTORY}
+
+# Define the in-jujubox and juju functions.
+source ./define-juju.sh
+# Define the utilities such as the run_and_wait function.
+source ./utilities.sh
+
+# Run the e2e test action.
+ACTION_ID=$(juju run-action kubernetes-e2e/0 test | cut -d " " -f 5)
+# Wait in 5 second increments for the action to be complete.
+run_and_wait "juju show-action-status ${ACTION_ID}" "status: completed" 5
+# Print out the action result.
+juju show-action-status ${ACTION_ID}
+
+# Download results from the charm and move them to the the volume directory.
+in-jujubox "juju scp kubernetes-e2e/0:${ACTION_ID}.log.tar.gz e2e.log.tar.gz && sudo mv e2e.log.tar.gz /home/ubuntu/workspace"
+in-jujubox "juju scp kubernetes-e2e/0:${ACTION_ID}-junit.tar.gz e2e-junit.tar.gz && sudo mv e2e-junit.tar.gz /home/ubuntu/workspace"
+
+# Extract the results into the output directory.
+tar -xvfz e2e-junit.tar.gz -C ${OUTPUT_DIRECTORY}
+tar -xvfz e2e.log.tar.gz -C ${OUTPUT_DIRECTORY}
+# Rename the ACTION_ID log file to build-log.txt
+mv ${OUTPUT_DIRECTORY}/${ACTION_ID}.log ${OUTPUT_DIRECTORY}/build-log.txt
+
+echo "${0} completed successfully at `date`."

--- a/utilities.sh
+++ b/utilities.sh
@@ -1,3 +1,37 @@
+# Define some common utility functions that are used by other scripts here.
+
+
+# The maximum amount of seconds to wait in a loop.
+MAXIMUM_WAIT_SECONDS=3600
+
+# The check_time function requires two parameters start_time and max_seconds.
+function check_time() {
+  local start_time=${1}
+  local maximum_seconds=${2}
+  local current_time=`date +"%s"`
+  local difference=$(expr ${current_time} - ${start_time})
+  # When the difference is greater than maximum seconds, exit this script.
+  if [ ${difference} -gt ${maximum_seconds} ]; then
+    echo "The process is taking more than ${maximum_seconds} seconds!"
+    # End this script because too much time has passed.
+    exit 3
+  fi
+}
+
+# Run a command in a loop waiting for specific output use MAXIMUM_WAIT_SECONDS.
+function run_and_wait() {
+  local cmd=${1}
+  local match=${2}
+  local sleep_seconds=${3:-5}
+  local start_time=`date +"%s"`
+  # Run the command in a loop looking for output.
+  until $(${cmd} | grep -q "${match}"); do 
+    # Check the time so this does not loop forever.
+    check_time ${start_time} ${MAXIMUM_WAIT_SECONDS}
+    sleep ${sleep_seconds}
+  done
+}
+
 # A platform neutral way to get the md5 hash sum of a file.
 function md5sum_file() {
   if which md5sum > /dev/null 2>&1; then

--- a/wait-cluster-ready.sh
+++ b/wait-cluster-ready.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Waits for a Kubernetes cluster to be fully deployed and ready to test.
+
+set -o errexit  # Exit when an individual command fails.
+set -o pipefail  # The exit status of the last command is returned.
+set -o xtrace  # Print the commands that are executed.
+
+echo "${0} started at `date`."
+
+# Define the in-jujubox and juju functions.
+source ./define-juju.sh
+# Define the utility functions such as run_and_wait.
+source ./utilities.sh
+
+# Wait in 10 second increments for the master charm to print running in status.
+run_and_wait "juju status kubernetes-master" "Kubernetes master running." 10
+
+# Wait in 10 second increments for "KubeDNS" to show up in cluster-info output.
+run_and_wait 'juju run --application kubernetes-master "kubectl cluster-info"' "KubeDNS" 10
+
+echo "${0} completed successfully at `date`."


### PR DESCRIPTION
Only the jenkins*.sh files should use Jenkins environment variables.
This took a bit of refactoring, hope it came out OK.