### PR TITLE
Make the build-and-release-all script work

### DIFF
--- a/charms/build-and-release-all.sh
+++ b/charms/build-and-release-all.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eux
 
+export CLOUD=aws
+export RELEASE=true
+export RELEASE_TO_CHANNEL=edge
+
 ./charms/build-and-release-easyrsa.sh
 ./charms/build-and-release-etcd.sh
 ./charms/build-and-release-flannel.sh

--- a/charms/build-and-release-bundles.sh
+++ b/charms/build-and-release-bundles.sh
@@ -19,3 +19,25 @@ PUSH_CMD="/usr/bin/charm push ./bundles/core-flannel ${CORE}"
 CORE_REVISION=`${PUSH_CMD} | tail -n +1 | head -1 | awk '{print $2}'`
 /usr/bin/charm release --channel edge ${CORE_REVISION}
 /usr/bin/charm grant --channel edge ${CORE_REVISION} everyone
+
+if [ "$RUN_TESTS" = "true" ]; then
+  export CHANNEL="edge"
+  export RUN_MATRIX_TESTS=true
+  export BUNDLE_NAME="canonical-kubernetes"
+  export CLOUD=google
+  ./tests/test-bundle.sh
+  export CLOUD=aws
+  ./tests/test-bundle.sh
+  export BUNDLE_NAME="kubernetes-core"
+  export CLOUD=google
+  ./tests/test-bundle.sh
+  export CLOUD=aws
+  ./tests/test-bundle.sh
+
+  export FROM_CHANNEL=edge
+  export TO_CHANNEL=beta
+  export BUNDLE_NAME_AND_REVISION=$(charm show cs:~containers/bundle/canonical-kubernetes --channel edge id | grep Id | awk '{print $2}')
+  ./charms/release-bundle-to-channel.sh
+  export BUNDLE_NAME_AND_REVISION=$(charm show cs:~containers/bundle/kubernetes-core --channel edge id | grep Id | awk '{print $2}')
+  ./charms/release-bundle-to-channel.sh
+fi

--- a/charms/build-and-release-easyrsa.sh
+++ b/charms/build-and-release-easyrsa.sh
@@ -44,6 +44,6 @@ touch report.xml
 if [ ${RELEASE} = true ]; then
   CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/easyrsa cs:~containers/easyrsa | head -n 1 | awk '{print $2}')
   echo "Releasing ${CHARM}"
-  charm release ${CHARM} --channel ${RELEASE_TO_CHANNEL} -r easyrsa-${RESOURCE_REV}
+  ./charms/charm-release-with-latest-resources.sh ${CHARM} --channel ${RELEASE_TO_CHANNEL}
   charm grant ${CHARM} everyone --channel ${RELEASE_TO_CHANNEL}
 fi

--- a/charms/build-and-release-easyrsa.sh
+++ b/charms/build-and-release-easyrsa.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
-# Runs the charm build for the Canonical Kubernetes charms.
+set -eux
 
-set -o errexit  # Exit when an individual command fails.
-set -o nounset  # Exit when undeclaried variables are used.
-set -o pipefail  # The exit status of the last command is returned.
-set -o xtrace  # Print the commands that are executed.
-
+export GIT_REPO="${GIT_REPO:-https://github.com/juju-solutions/layer-easyrsa.git}"
 
 echo "${0} started at `date`."
 

--- a/charms/build-and-release-etcd.sh
+++ b/charms/build-and-release-etcd.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
-# Runs the charm build for the Canonical Kubernetes charms.
+set -eux
 
-set -o errexit  # Exit when an individual command fails.
-set -o nounset  # Exit when undeclaried variables are used.
-set -o pipefail  # The exit status of the last command is returned.
-set -o xtrace  # Print the commands that are executed.
-
+export GIT_REPO="${GIT_REPO:-https://github.com/juju-solutions/layer-etcd.git}"
 
 echo "${0} started at `date`."
 

--- a/charms/build-and-release-etcd.sh
+++ b/charms/build-and-release-etcd.sh
@@ -44,6 +44,6 @@ touch report.xml
 if [ ${RELEASE} = true ]; then
   ETCD_CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/etcd cs:~containers/etcd | head -n 1 | awk '{print $2}')
   echo "Releasing ${ETCD_CHARM}"
-  charm release ${ETCD_CHARM} --channel ${RELEASE_TO_CHANNEL} -r etcd-3 -r snapshot-0
+  ./charms/charm-release-with-latest-resources.sh ${ETCD_CHARM} --channel ${RELEASE_TO_CHANNEL}
   charm grant ${ETCD_CHARM} everyone --channel ${RELEASE_TO_CHANNEL}
 fi

--- a/charms/build-and-release-flannel.sh
+++ b/charms/build-and-release-flannel.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
-# Runs the charm build for the Canonical Kubernetes charms.
+set -eux
 
-set -o errexit  # Exit when an individual command fails.
-set -o nounset  # Exit when undeclaried variables are used.
-set -o pipefail  # The exit status of the last command is returned.
-set -o xtrace  # Print the commands that are executed.
-
+export GIT_REPO="${GIT_REPO:-https://github.com/juju-solutions/charm-flannel.git}"
 
 echo "${0} started at `date`."
 

--- a/charms/build-and-release-flannel.sh
+++ b/charms/build-and-release-flannel.sh
@@ -44,6 +44,6 @@ touch report.xml
 if [ ${RELEASE} = true ]; then
   CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/flannel cs:~containers/flannel | head -n 1 | awk '{print $2}')
   echo "Releasing ${CHARM}"
-  charm release ${CHARM} --channel ${RELEASE_TO_CHANNEL} -r flannel-${RESOURCE_REV}
+  ./charms/charm-release-with-latest-resources.sh ${CHARM} --channel ${RELEASE_TO_CHANNEL}
   charm grant ${CHARM} everyone --channel ${RELEASE_TO_CHANNEL}
 fi

--- a/charms/build-and-release-kubeapi-load-balancer.sh
+++ b/charms/build-and-release-kubeapi-load-balancer.sh
@@ -14,7 +14,9 @@ CLOUD=${CLOUD:-"google"}
 
 
 # Clone the git repo
-git clone ${GIT_REPO}
+if ! [ -d kubernetes ]; then
+  git clone ${GIT_REPO}
+fi
 
 # Build the charm with no local layers
 cd kubernetes/cluster/juju/layers/kubeapi-load-balancer

--- a/charms/build-and-release-kubeapi-load-balancer.sh
+++ b/charms/build-and-release-kubeapi-load-balancer.sh
@@ -46,6 +46,6 @@ touch report.xml
 if [ ${RELEASE} = true ]; then
   CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/kubeapi-load-balancer cs:~containers/kubeapi-load-balancer | head -n 1 | awk '{print $2}')
   echo "Releasing ${CHARM}"
-  charm release ${CHARM} --channel ${RELEASE_TO_CHANNEL} 
+  ./charms/charm-release-with-latest-resources.sh ${CHARM} --channel ${RELEASE_TO_CHANNEL}
   charm grant ${CHARM} everyone --channel ${RELEASE_TO_CHANNEL}
 fi

--- a/charms/build-and-release-kubeapi-load-balancer.sh
+++ b/charms/build-and-release-kubeapi-load-balancer.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
-# Runs the charm build for the Canonical Kubernetes charms.
+set -eux
 
-set -o errexit  # Exit when an individual command fails.
-set -o nounset  # Exit when undeclaried variables are used.
-set -o pipefail  # The exit status of the last command is returned.
-set -o xtrace  # Print the commands that are executed.
-
+export GIT_REPO="${GIT_REPO:-https://github.com/kubernetes/kubernetes.git}"
 
 echo "${0} started at `date`."
 

--- a/charms/build-and-release-kubernetes-e2e.sh
+++ b/charms/build-and-release-kubernetes-e2e.sh
@@ -14,7 +14,9 @@ CLOUD=${CLOUD:-"google"}
 
 
 # Clone the git repo
-git clone ${GIT_REPO}
+if ! [ -d kubernetes ]; then
+  git clone ${GIT_REPO}
+fi
 
 # Build the charm with no local layers
 cd kubernetes/cluster/juju/layers/kubernetes-e2e

--- a/charms/build-and-release-kubernetes-e2e.sh
+++ b/charms/build-and-release-kubernetes-e2e.sh
@@ -46,6 +46,6 @@ touch report.xml
 if [ ${RELEASE} = true ]; then
   CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/kubernetes-e2e cs:~containers/kubernetes-e2e | head -n 1 | awk '{print $2}')
   echo "Releasing ${CHARM}"
-  charm release ${CHARM} --channel ${RELEASE_TO_CHANNEL} -r kubectl-0 -r kubernetes-test-0
+  ./charms/charm-release-with-latest-resources.sh ${CHARM} --channel ${RELEASE_TO_CHANNEL}
   charm grant ${CHARM} everyone --channel ${RELEASE_TO_CHANNEL}
 fi

--- a/charms/build-and-release-kubernetes-e2e.sh
+++ b/charms/build-and-release-kubernetes-e2e.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
-# Runs the charm build for the Canonical Kubernetes charms.
+set -eux
 
-set -o errexit  # Exit when an individual command fails.
-set -o nounset  # Exit when undeclaried variables are used.
-set -o pipefail  # The exit status of the last command is returned.
-set -o xtrace  # Print the commands that are executed.
-
+export GIT_REPO="${GIT_REPO:-https://github.com/kubernetes/kubernetes.git}"
 
 echo "${0} started at `date`."
 

--- a/charms/build-and-release-kubernetes-master.sh
+++ b/charms/build-and-release-kubernetes-master.sh
@@ -46,6 +46,6 @@ touch report.xml
 if [ ${RELEASE} = true ]; then
   CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/kubernetes-master cs:~containers/kubernetes-master | head -n 1 | awk '{print $2}')
   echo "Releasing ${CHARM}"
-  charm release ${CHARM} --channel ${RELEASE_TO_CHANNEL} -r cdk-addons-0 -r kube-apiserver-0 -r kube-controller-manager-0 -r kube-scheduler-0 -r kubectl-0
+  ./charms/charm-release-with-latest-resources.sh ${CHARM} --channel ${RELEASE_TO_CHANNEL}
   charm grant ${CHARM} everyone --channel ${RELEASE_TO_CHANNEL}
 fi

--- a/charms/build-and-release-kubernetes-master.sh
+++ b/charms/build-and-release-kubernetes-master.sh
@@ -14,7 +14,9 @@ CLOUD=${CLOUD:-"google"}
 
 
 # Clone the git repo
-git clone ${GIT_REPO}
+if ! [ -d kubernetes ]; then
+  git clone ${GIT_REPO}
+fi
 
 # Build the charm with no local layers
 cd kubernetes/cluster/juju/layers/kubernetes-master

--- a/charms/build-and-release-kubernetes-master.sh
+++ b/charms/build-and-release-kubernetes-master.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
-# Runs the charm build for the Canonical Kubernetes charms.
+set -eux
 
-set -o errexit  # Exit when an individual command fails.
-set -o nounset  # Exit when undeclaried variables are used.
-set -o pipefail  # The exit status of the last command is returned.
-set -o xtrace  # Print the commands that are executed.
-
+export GIT_REPO="${GIT_REPO:-https://github.com/kubernetes/kubernetes.git}"
 
 echo "${0} started at `date`."
 

--- a/charms/build-and-release-kubernetes-worker.sh
+++ b/charms/build-and-release-kubernetes-worker.sh
@@ -46,6 +46,6 @@ touch report.xml
 if [ ${RELEASE} = true ]; then
   CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/kubernetes-worker cs:~containers/kubernetes-worker | head -n 1 | awk '{print $2}')
   echo "Releasing ${CHARM}"
-  charm release ${CHARM} --channel ${RELEASE_TO_CHANNEL}  -r cni-0 -r kube-proxy-0 -r kubectl-0 -r kubelet-0
+  ./charms/charm-release-with-latest-resources.sh ${CHARM} --channel ${RELEASE_TO_CHANNEL}
   charm grant ${CHARM} everyone --channel ${RELEASE_TO_CHANNEL}
 fi

--- a/charms/build-and-release-kubernetes-worker.sh
+++ b/charms/build-and-release-kubernetes-worker.sh
@@ -14,7 +14,9 @@ CLOUD=${CLOUD:-"google"}
 
 
 # Clone the git repo
-git clone ${GIT_REPO}
+if ! [ -d kubernetes ]; then
+  git clone ${GIT_REPO}
+fi
 
 # Build the charm with no local layers
 cd kubernetes/cluster/juju/layers/kubernetes-worker

--- a/charms/build-and-release-kubernetes-worker.sh
+++ b/charms/build-and-release-kubernetes-worker.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
-# Runs the charm build for the Canonical Kubernetes charms.
+set -eux
 
-set -o errexit  # Exit when an individual command fails.
-set -o nounset  # Exit when undeclaried variables are used.
-set -o pipefail  # The exit status of the last command is returned.
-set -o xtrace  # Print the commands that are executed.
-
+export GIT_REPO="${GIT_REPO:-https://github.com/kubernetes/kubernetes.git}"
 
 echo "${0} started at `date`."
 

--- a/charms/charm-release-with-latest-resources.sh
+++ b/charms/charm-release-with-latest-resources.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eux
+
+# Releases a charm with the resources that are currently attached to it.
+# $1: charm URL
+# $@: remaining arguments to `charm release`, e.g. --channel edge
+
+CHARM="$1"
+shift
+
+declare -a RESOURCE_ARGS=()
+RESOURCES="$(charm list-resources "$CHARM" | tail -n +3 | sed -e '/^$/d' -e 's/  */-/g')"
+for resource in $RESOURCES; do
+  RESOURCE_ARGS+=('-r')
+  RESOURCE_ARGS+=("$resource")
+done
+
+(set +u # allows expansion of empty RESOURCE_ARGS
+  charm release "$CHARM" "$@" "${RESOURCE_ARGS[@]}"
+)


### PR DESCRIPTION
Making the build-and-release-all.sh script work. This brings in functionality that was previously covered by the big-red-button job.