### PR TITLE
Fix wrong working directory after charm builds

### DIFF
--- a/charms/build-and-release-kubeapi-load-balancer.sh
+++ b/charms/build-and-release-kubeapi-load-balancer.sh
@@ -19,9 +19,9 @@ if ! [ -d kubernetes ]; then
 fi
 
 # Build the charm with no local layers
-cd kubernetes/cluster/juju/layers/kubeapi-load-balancer
-charm build -r --no-local-layers --force
-cd ..
+(cd kubernetes/cluster/juju/layers/kubeapi-load-balancer
+  charm build -r --no-local-layers --force
+)
 
 if [ ${RUN_TESTS} = true ]; then
   JUJU_CONTROLLER="jenkins-ci-${CLOUD}"

--- a/charms/build-and-release-kubernetes-e2e.sh
+++ b/charms/build-and-release-kubernetes-e2e.sh
@@ -19,9 +19,9 @@ if ! [ -d kubernetes ]; then
 fi
 
 # Build the charm with no local layers
-cd kubernetes/cluster/juju/layers/kubernetes-e2e
-charm build -r --no-local-layers --force
-cd ..
+(cd kubernetes/cluster/juju/layers/kubernetes-e2e
+  charm build -r --no-local-layers --force
+)
 
 if [ ${RUN_TESTS} = true ]; then
   JUJU_CONTROLLER="jenkins-ci-${CLOUD}"

--- a/charms/build-and-release-kubernetes-master.sh
+++ b/charms/build-and-release-kubernetes-master.sh
@@ -19,9 +19,9 @@ if ! [ -d kubernetes ]; then
 fi
 
 # Build the charm with no local layers
-cd kubernetes/cluster/juju/layers/kubernetes-master
-charm build -r --no-local-layers --force
-cd ..
+(cd kubernetes/cluster/juju/layers/kubernetes-master
+  charm build -r --no-local-layers --force
+)
 
 if [ ${RUN_TESTS} = true ]; then
   JUJU_CONTROLLER="jenkins-ci-${CLOUD}"

--- a/charms/build-and-release-kubernetes-worker.sh
+++ b/charms/build-and-release-kubernetes-worker.sh
@@ -19,9 +19,9 @@ if ! [ -d kubernetes ]; then
 fi
 
 # Build the charm with no local layers
-cd kubernetes/cluster/juju/layers/kubernetes-worker
-charm build -r --no-local-layers --force
-cd ..
+(cd kubernetes/cluster/juju/layers/kubernetes-worker
+  charm build -r --no-local-layers --force
+)
 
 if [ ${RUN_TESTS} = true ]; then
   JUJU_CONTROLLER="jenkins-ci-${CLOUD}"


### PR DESCRIPTION
Some builds are failing because we don't restore the working directory properly after the charm build. This should fix that.