### PR TITLE
Improve test reporting

### DIFF
--- a/tests/run-bundle-tests.sh
+++ b/tests/run-bundle-tests.sh
@@ -22,7 +22,8 @@ rm -rf results
 for controller in $TEST_CONTROLLERS; do
   juju switch "$controller"
   for bundle in $TEST_BUNDLES; do
-    result_dir="results/$(echo $bundle | sed 's|/|_|g')/$controller"
+    bundle_dir="$(echo "$bundle" | sed -e 's|^cs:~||' -e 's|/|_|g')"
+    result_dir="results/$bundle_dir/$controller"
     mkdir -p "$result_dir"
     export TEST_RESULT_DIR="$(readlink -f "$result_dir")"
 

--- a/tests/run-bundle-tests.sh
+++ b/tests/run-bundle-tests.sh
@@ -30,7 +30,7 @@ for controller in $TEST_CONTROLLERS; do
     juju add-model "$model" --config test-mode=true
     (trap "juju destroy-model -y $model" EXIT
       rm -rf bundle-under-test
-      charm pull canonical-kubernetes --channel "$TEST_BUNDLE_CHANNEL" bundle-under-test
+      charm pull "$bundle" --channel "$TEST_BUNDLE_CHANNEL" bundle-under-test
       ./tests/set-snap-channel.py bundle-under-test "$TEST_SNAP_CHANNEL"
 
       bundletester --no-matrix -vF -l DEBUG -t bundle-under-test -r xml -o "$result_dir/bundletester.xml"

--- a/tests/run-bundle-tests.sh
+++ b/tests/run-bundle-tests.sh
@@ -17,9 +17,15 @@ TEST_CONTROLLERS="${TEST_CONTROLLERS:-$(juju switch | cut -d ':' -f 1)}"
 TEST_BUNDLE_CHANNEL="${TEST_BUNDLE_CHANNEL:-edge}"
 TEST_SNAP_CHANNEL="${TEST_SNAP_CHANNEL:-1.6/edge}"
 
+rm -rf results
+
 for controller in $TEST_CONTROLLERS; do
   juju switch "$controller"
   for bundle in $TEST_BUNDLES; do
+    result_dir="results/$(echo $bundle | sed 's|/|_|g')/$controller"
+    mkdir -p "$result_dir"
+    export TEST_RESULT_DIR="$(readlink -f "$result_dir")"
+
     model="cdk-build-$RANDOM"
     juju add-model "$model" --config test-mode=true
     (trap "juju destroy-model -y $model" EXIT
@@ -27,7 +33,7 @@ for controller in $TEST_CONTROLLERS; do
       charm pull canonical-kubernetes --channel "$TEST_BUNDLE_CHANNEL" bundle-under-test
       ./tests/set-snap-channel.py bundle-under-test "$TEST_SNAP_CHANNEL"
 
-      bundletester --no-matrix -vF -l DEBUG -t bundle-under-test -r xml -o bundle-test-results.xml
+      bundletester --no-matrix -vF -l DEBUG -t bundle-under-test -r xml -o "$result_dir/bundletester.xml"
     )
   done
 done


### PR DESCRIPTION
Depends on https://github.com/juju-solutions/bundle-canonical-kubernetes/pull/292

* Fixes bundle-test-results.xml being overwritten by runs on different controllers/bundles
* Fixes pulling the wrong bundle, oops

This also paves the way for us reporting e2e junit results alongside the ones coming from bundletester. Haven't done that yet though.