### PR TITLE
Default KUBE_VERSION to latest stable for snap builds

### DIFF
--- a/snaps/build-and-release-k8s-snaps.sh
+++ b/snaps/build-and-release-k8s-snaps.sh
@@ -2,6 +2,7 @@
 
 set -eux
 
+KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
 KUBE_ARCH="amd64"
 
 git clone https://github.com/juju-solutions/release.git --branch rye/snaps --depth 1


### PR DESCRIPTION
If KUBE_VERSION is unset or empty, default to the latest stable release of Kubernetes.

This is needed for nightly snap builds.