### PR TITLE
Retry snapcraft push command 3 times

### DIFF
--- a/snaps/build-and-release-k8s-snaps.sh
+++ b/snaps/build-and-release-k8s-snaps.sh
@@ -5,6 +5,21 @@ set -eux
 KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
 KUBE_ARCH="amd64"
 
+retry() {
+  (set +e
+    for i in $(seq 3); do
+      "$@"
+      exit_code="$?"
+      if [ "$exit_code" -eq 0 ]; then
+        return 0
+      fi
+      sleep 1
+    done
+    echo "Command failed after 3 attempts: $@"
+    return "$exit_code"
+  )
+}
+
 git clone https://github.com/juju-solutions/release.git --branch rye/snaps --depth 1
 (cd release/snap
   make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH="$KUBE_ARCH" \
@@ -20,14 +35,14 @@ done
 
 for app in kubeadm kube-apiserver kubectl kubefed kubelet kube-proxy kube-scheduler; do
   for arch in $KUBE_ARCH; do
-    snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${arch}.snap --release ${KUBE_VERSION:1:3}/edge
+    retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${arch}.snap --release ${KUBE_VERSION:1:3}/edge
   done
 done
 
 for app in kube-controller-manager kubernetes-test; do
-  snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_amd64.snap --release ${KUBE_VERSION:1:3}/edge
+  retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_amd64.snap --release ${KUBE_VERSION:1:3}/edge
 done
 
 for arch in $KUBE_ARCH; do
-  snapcraft push cdk-addons/cdk-addons_${KUBE_VERSION:1}_${arch}.snap --release ${KUBE_VERSION:1:3}/edge
+  retry snapcraft push cdk-addons/cdk-addons_${KUBE_VERSION:1}_${arch}.snap --release ${KUBE_VERSION:1:3}/edge
 done


### PR DESCRIPTION
Workaround for a build failure:

```
+ snapcraft push release/snap/build/kubeadm_1.6.4_amd64.snap --release 1.6/edge
...
The store was unable to accept this snap.
  - Service unavailable. Please try again later. (['OOPS-bd7063ed161fea36d831f017c5786716'])
Error while processing...
```

Let's just retry it a couple times. It won't save us all the time, but might help some.