### PR TITLE
Initial upgrade tests

### DIFF
--- a/tests/upgrade-tests/README.md
+++ b/tests/upgrade-tests/README.md
@@ -1,0 +1,20 @@
+# CDK upgrade tests
+
+## Install
+
+Dependencies can be installed by running:
+```
+./install-deps.sh
+```
+
+## Running tests
+
+To run all tests:
+```
+pytest
+```
+
+Individual test files can be passed to pytest:
+```
+pytest test_upgrade_charms.py
+```

--- a/tests/upgrade-tests/README.md
+++ b/tests/upgrade-tests/README.md
@@ -9,12 +9,19 @@ Dependencies can be installed by running:
 
 ## Running tests
 
+This test suite assumes that a juju controller has already been bootstrapped.
+
+Select the juju controller you want to use:
+```
+juju switch my-controller
+```
+
 To run all tests:
 ```
 pytest
 ```
 
-Individual test files can be passed to pytest:
+To run tests from a single file:
 ```
 pytest test_upgrade_charms.py
 ```

--- a/tests/upgrade-tests/install-deps.sh
+++ b/tests/upgrade-tests/install-deps.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eux
+
+# Installs dependencies needed for upgrade tests
+# Can be run again to upgrade dependencies.
+
+sudo pip3 install -U pytest pytest-asyncio asyncio_extras juju

--- a/tests/upgrade-tests/test_deploy.py
+++ b/tests/upgrade-tests/test_deploy.py
@@ -4,8 +4,8 @@ from validation import validate_all
 
 test_cases = [
     # bundle                 # channel
-    ('kubernetes-core',      'beta'),
-    ('canonical-kubernetes', 'beta'),
+    ('kubernetes-core',      'edge'),
+    ('canonical-kubernetes', 'edge'),
 ]
 
 

--- a/tests/upgrade-tests/test_deploy.py
+++ b/tests/upgrade-tests/test_deploy.py
@@ -1,0 +1,18 @@
+import pytest
+from utils import temporary_model, wait_for_ready
+from validation import validate_all
+
+test_cases = [
+    # bundle                 # channel
+    ('kubernetes-core',      'beta'),
+    ('canonical-kubernetes', 'beta'),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('bundle,channel', test_cases)
+async def test_deploy(bundle, channel):
+    async with temporary_model() as model:
+        await model.deploy(bundle, channel=channel)
+        await wait_for_ready(model)
+        await validate_all(model)

--- a/tests/upgrade-tests/test_upgrade_charms.py
+++ b/tests/upgrade-tests/test_upgrade_charms.py
@@ -1,5 +1,6 @@
 import pytest
-from utils import temporary_model, wait_for_ready, assert_healthy
+from utils import temporary_model, wait_for_ready
+from validation import validate_all
 
 test_cases = [
     # bundle                 from_channel  to_channel
@@ -17,4 +18,4 @@ async def test_upgrade_charms(bundle, from_channel, to_channel):
         for app in model.applications.values():
             await app.upgrade_charm(channel=to_channel)
         await wait_for_ready(model)
-        assert_healthy(model)
+        await validate_all(model)

--- a/tests/upgrade-tests/test_upgrade_charms.py
+++ b/tests/upgrade-tests/test_upgrade_charms.py
@@ -7,18 +7,14 @@ test_cases = [
     ('canonical-kubernetes', 'stable',     'beta'),
 ]
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize('bundle,from_channel,to_channel', test_cases)
 async def test_upgrade_charms(bundle, from_channel, to_channel):
     async with temporary_model() as model:
         await model.deploy(bundle, channel=from_channel)
         await wait_for_ready(model)
-        await model.applications['easyrsa'].upgrade_charm(channel=to_channel)
-        await model.applications['etcd'].upgrade_charm(channel=to_channel)
-        await model.applications['flannel'].upgrade_charm(channel=to_channel)
-        await model.applications['kubernetes-master'].upgrade_charm(channel=to_channel)
-        await model.applications['kubernetes-worker'].upgrade_charm(channel=to_channel)
-        if 'kubeapi-load-balancer' in model.applications:
-            await model.applications['kubeapi-load-balancer'].upgrade_charm(channel=to_channel)
+        for app in model.applications.values():
+            app.upgrade_charm(channel=to_channel)
         await wait_for_ready(model)
         assert_healthy(model)

--- a/tests/upgrade-tests/test_upgrade_charms.py
+++ b/tests/upgrade-tests/test_upgrade_charms.py
@@ -4,8 +4,8 @@ from validation import validate_all
 
 test_cases = [
     # bundle                 from_channel  to_channel
-    ('kubernetes-core',      'stable',     'beta'),
-    ('canonical-kubernetes', 'stable',     'beta'),
+    ('kubernetes-core',      'stable',     'edge'),
+    ('canonical-kubernetes', 'stable',     'edge'),
 ]
 
 

--- a/tests/upgrade-tests/test_upgrade_charms.py
+++ b/tests/upgrade-tests/test_upgrade_charms.py
@@ -15,6 +15,6 @@ async def test_upgrade_charms(bundle, from_channel, to_channel):
         await model.deploy(bundle, channel=from_channel)
         await wait_for_ready(model)
         for app in model.applications.values():
-            app.upgrade_charm(channel=to_channel)
+            await app.upgrade_charm(channel=to_channel)
         await wait_for_ready(model)
         assert_healthy(model)

--- a/tests/upgrade-tests/test_upgrade_charms.py
+++ b/tests/upgrade-tests/test_upgrade_charms.py
@@ -1,18 +1,22 @@
 import pytest
 from utils import temporary_model, wait_for_ready, assert_healthy
 
-CHARMS_UPGRADE_FROM="stable"
-CHARMS_UPGRADE_TO="beta"
+test_cases = [
+    # bundle                 from_channel  to_channel
+    ('kubernetes-core',      'stable',     'beta'),
+    ('canonical-kubernetes', 'stable',     'beta'),
+]
 
 @pytest.mark.asyncio
-async def test_upgrade_charms():
+@pytest.mark.parametrize('bundle,from_channel,to_channel', test_cases)
+async def test_upgrade_charms(bundle, from_channel, to_channel):
     async with temporary_model() as model:
-        await model.deploy("kubernetes-core", channel=CHARMS_UPGRADE_FROM)
+        await model.deploy(bundle, channel=from_channel)
         await wait_for_ready(model)
-        await model.applications["easyrsa"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
-        await model.applications["etcd"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
-        await model.applications["flannel"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
-        await model.applications["kubernetes-master"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
-        await model.applications["kubernetes-worker"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
+        await model.applications['easyrsa'].upgrade_charm(channel=to_channel)
+        await model.applications['etcd'].upgrade_charm(channel=to_channel)
+        await model.applications['flannel'].upgrade_charm(channel=to_channel)
+        await model.applications['kubernetes-master'].upgrade_charm(channel=to_channel)
+        await model.applications['kubernetes-worker'].upgrade_charm(channel=to_channel)
         await wait_for_ready(model)
         assert_healthy(model)

--- a/tests/upgrade-tests/test_upgrade_charms.py
+++ b/tests/upgrade-tests/test_upgrade_charms.py
@@ -18,5 +18,7 @@ async def test_upgrade_charms(bundle, from_channel, to_channel):
         await model.applications['flannel'].upgrade_charm(channel=to_channel)
         await model.applications['kubernetes-master'].upgrade_charm(channel=to_channel)
         await model.applications['kubernetes-worker'].upgrade_charm(channel=to_channel)
+        if 'kubeapi-load-balancer' in model.applications:
+            await model.applications['kubeapi-load-balancer'].upgrade_charm(channel=to_channel)
         await wait_for_ready(model)
         assert_healthy(model)

--- a/tests/upgrade-tests/test_upgrade_charms.py
+++ b/tests/upgrade-tests/test_upgrade_charms.py
@@ -1,0 +1,18 @@
+import pytest
+from utils import temporary_model, wait_for_ready, assert_healthy
+
+CHARMS_UPGRADE_FROM="stable"
+CHARMS_UPGRADE_TO="beta"
+
+@pytest.mark.asyncio
+async def test_upgrade_charms():
+    async with temporary_model() as model:
+        await model.deploy("kubernetes-core", channel=CHARMS_UPGRADE_FROM)
+        await wait_for_ready(model)
+        await model.applications["easyrsa"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
+        await model.applications["etcd"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
+        await model.applications["flannel"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
+        await model.applications["kubernetes-master"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
+        await model.applications["kubernetes-worker"].upgrade_charm(channel=CHARMS_UPGRADE_TO)
+        await wait_for_ready(model)
+        assert_healthy(model)

--- a/tests/upgrade-tests/test_upgrade_snaps.py
+++ b/tests/upgrade-tests/test_upgrade_snaps.py
@@ -4,10 +4,10 @@ from validation import validate_all
 
 test_cases = [
     # bundle                 charm_channel  from_channel  to_channel
-    ('kubernetes-core',      'beta',        '1.6/stable', '1.6/edge'),
-    ('kubernetes-core',      'beta',        '1.6/stable', '1.7/edge'),
-    ('canonical-kubernetes', 'beta',        '1.6/stable', '1.6/edge'),
-    ('canonical-kubernetes', 'beta',        '1.6/stable', '1.7/edge'),
+    ('kubernetes-core',      'edge',        '1.6/stable', '1.6/edge'),
+    ('kubernetes-core',      'edge',        '1.6/stable', '1.7/edge'),
+    ('canonical-kubernetes', 'edge',        '1.6/stable', '1.6/edge'),
+    ('canonical-kubernetes', 'edge',        '1.6/stable', '1.7/edge'),
 ]
 
 

--- a/tests/upgrade-tests/test_upgrade_snaps.py
+++ b/tests/upgrade-tests/test_upgrade_snaps.py
@@ -21,7 +21,8 @@ async def set_snap_channel(model, channel):
 @pytest.mark.parametrize('bundle,from_channel,to_channel', test_cases)
 async def test_upgrade_snaps(bundle, from_channel, to_channel):
     async with temporary_model() as model:
-        await model.deploy(bundle, channel='stable')
+        # FIXME: this should be channel='edge' once the edge channel works
+        await model.deploy(bundle, channel='beta')
         await set_snap_channel(model, from_channel)
         await wait_for_ready(model)
         await set_snap_channel(model, to_channel)

--- a/tests/upgrade-tests/test_upgrade_snaps.py
+++ b/tests/upgrade-tests/test_upgrade_snaps.py
@@ -9,16 +9,22 @@ test_cases = [
     ('canonical-kubernetes', '1.6/stable', '1.7/edge'),
 ]
 
+
+async def set_snap_channel(model, channel):
+    master = model.applications['kubernetes-master']
+    await master.set_config({'channel': channel})
+    worker = model.applications['kubernetes-worker']
+    await worker.set_config({'channel': channel})
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize('bundle,from_channel,to_channel', test_cases)
 async def test_upgrade_snaps(bundle, from_channel, to_channel):
     async with temporary_model() as model:
         await model.deploy(bundle, channel='stable')
-        await model.applications['kubernetes-master'].set_config({'channel': from_channel})
-        await model.applications['kubernetes-worker'].set_config({'channel': from_channel})
+        await set_snap_channel(model, from_channel)
         await wait_for_ready(model)
-        await model.applications['kubernetes-master'].set_config({'channel': to_channel})
-        await model.applications['kubernetes-worker'].set_config({'channel': to_channel})
+        await set_snap_channel(model, to_channel)
         for unit in model.applications['kubernetes-worker'].units:
             action = await unit.run_action('upgrade')
             await action.wait()

--- a/tests/upgrade-tests/test_upgrade_snaps.py
+++ b/tests/upgrade-tests/test_upgrade_snaps.py
@@ -1,0 +1,21 @@
+import pytest
+from utils import temporary_model, wait_for_ready, assert_healthy
+
+SNAPS_UPGRADE_FROM='1.6/stable'
+SNAPS_UPGRADE_TO='1.6/edge'
+
+@pytest.mark.asyncio
+async def test_upgrade_snaps():
+    async with temporary_model() as model:
+        await model.deploy('kubernetes-core', channel='stable')
+        await model.applications['kubernetes-master'].set_config({'channel': SNAPS_UPGRADE_FROM})
+        await model.applications['kubernetes-worker'].set_config({'channel': SNAPS_UPGRADE_FROM})
+        await wait_for_ready(model)
+        await model.applications['kubernetes-master'].set_config({'channel': SNAPS_UPGRADE_TO})
+        await model.applications['kubernetes-worker'].set_config({'channel': SNAPS_UPGRADE_TO})
+        for unit in model.applications['kubernetes-worker'].units:
+            action = await unit.run_action('upgrade')
+            await action.wait()
+            assert action.status == 'completed'
+        await wait_for_ready(model)
+        assert_healthy(model)

--- a/tests/upgrade-tests/test_upgrade_snaps.py
+++ b/tests/upgrade-tests/test_upgrade_snaps.py
@@ -1,18 +1,24 @@
 import pytest
 from utils import temporary_model, wait_for_ready, assert_healthy
 
-SNAPS_UPGRADE_FROM='1.6/stable'
-SNAPS_UPGRADE_TO='1.6/edge'
+test_cases = [
+    # bundle                 from_channel  to_channel
+    ('kubernetes-core',      '1.6/stable', '1.6/edge'),
+    ('kubernetes-core',      '1.6/stable', '1.7/edge'),
+    ('canonical-kubernetes', '1.6/stable', '1.6/edge'),
+    ('canonical-kubernetes', '1.6/stable', '1.7/edge'),
+]
 
 @pytest.mark.asyncio
-async def test_upgrade_snaps():
+@pytest.mark.parametrize('bundle,from_channel,to_channel', test_cases)
+async def test_upgrade_snaps(bundle, from_channel, to_channel):
     async with temporary_model() as model:
-        await model.deploy('kubernetes-core', channel='stable')
-        await model.applications['kubernetes-master'].set_config({'channel': SNAPS_UPGRADE_FROM})
-        await model.applications['kubernetes-worker'].set_config({'channel': SNAPS_UPGRADE_FROM})
+        await model.deploy(bundle, channel='stable')
+        await model.applications['kubernetes-master'].set_config({'channel': from_channel})
+        await model.applications['kubernetes-worker'].set_config({'channel': from_channel})
         await wait_for_ready(model)
-        await model.applications['kubernetes-master'].set_config({'channel': SNAPS_UPGRADE_TO})
-        await model.applications['kubernetes-worker'].set_config({'channel': SNAPS_UPGRADE_TO})
+        await model.applications['kubernetes-master'].set_config({'channel': to_channel})
+        await model.applications['kubernetes-worker'].set_config({'channel': to_channel})
         for unit in model.applications['kubernetes-worker'].units:
             action = await unit.run_action('upgrade')
             await action.wait()

--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -45,9 +45,13 @@ async def wait_for_ready(model):
     # Subordinate units, for example, don't come into existence until after the
     # principal unit has settled.
     #
-    # If you see problems where this didn't wait long enough, it's probably that.
+    # If you see problems where this didn't wait long enough, it's probably
+    # that.
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 1800  # 15 minutes
     while not all_units_ready(model):
         assert_no_unit_errors(model)
+        assert loop.time() < deadline
         await asyncio.sleep(1)
     assert_no_unit_errors(model)
 
@@ -56,8 +60,8 @@ def assert_healthy(model):
     ''' Assert that the current deployment is healthy. '''
     assert_no_unit_errors(model)
     expected_messages = {
-      'kubernetes-master': 'Kubernetes master running.',
-      'kubernetes-worker': 'Kubernetes worker running.'
+        'kubernetes-master': 'Kubernetes master running.',
+        'kubernetes-worker': 'Kubernetes worker running.'
     }
     for app, message in expected_messages.items():
         for unit in model.applications[app].units:

--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -63,7 +63,7 @@ async def wait_for_ready(model):
     # If you see problems where this didn't wait long enough, it's probably
     # that.
     loop = asyncio.get_event_loop()
-    deadline = loop.time() + 1800  # 15 minutes
+    deadline = loop.time() + 1800  # 30 minutes
     while not all_units_ready(model):
         assert_no_unit_errors(model)
         assert loop.time() < deadline

--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -1,8 +1,20 @@
 import asyncio
+import json
 import random
+import sys
 from asyncio_extras import async_contextmanager
 from async_generator import yield_
 from juju.controller import Controller
+
+
+def dump_model_info(model):
+    ''' Dumps information about the model to stdout '''
+    data = {
+        'applications': {k: v.data for k, v in model.applications.items()},
+        'units': {k: v.data for k, v in model.units.items()},
+        'machines': {k: v.data for k, v in model.machines.items()}
+    }
+    json.dump(data, sys.stdout, indent=2)
 
 
 @async_contextmanager
@@ -17,6 +29,9 @@ async def temporary_model():
     model = await controller.add_model(model_name)
     try:
         await yield_(model)
+    except:
+        dump_model_info(model)
+        raise
     finally:
         await model.disconnect()
         await controller.destroy_model(model.info.uuid)

--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -1,0 +1,53 @@
+import asyncio
+import random
+from asyncio_extras import async_contextmanager
+from async_generator import yield_
+from juju.controller import Controller
+
+
+@async_contextmanager
+async def temporary_model():
+    controller = Controller()
+    await controller.connect_current()
+    model_name = "cdk-build-upgrade-%d" % random.randint(0, 10000)
+    model = await controller.add_model(model_name)
+    try:
+        await yield_(model)
+    finally:
+        await model.disconnect()
+        await controller.destroy_model(model.info.uuid)
+        await controller.disconnect()
+
+
+def assert_no_unit_errors(model):
+    for unit in model.units.values():
+        assert unit.data['workload-status']['current'] != 'error'
+
+
+def all_units_ready(model):
+    for unit in model.units.values():
+        if unit.data['workload-status']['current'] != 'active':
+            return False
+        if unit.data['agent-status']['current'] != 'idle':
+            return False
+    return True
+
+
+async def wait_for_ready(model):
+    """ Wait until all units are 'active' and 'idle'. """
+    # FIXME: It's possible this might not handle subordinates properly
+    while not all_units_ready(model):
+        assert_no_unit_errors(model)
+        await asyncio.sleep(1)
+    assert_no_unit_errors(model)
+
+
+def assert_healthy(model):
+    assert_no_unit_errors(model)
+    expected_messages = {
+      "kubernetes-master": "Kubernetes master running.",
+      "kubernetes-worker": "Kubernetes worker running."
+    }
+    for app, message in expected_messages.items():
+        for unit in model.applications[app].units:
+            assert unit.data['workload-status']['message'] == message

--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -7,9 +7,13 @@ from juju.controller import Controller
 
 @async_contextmanager
 async def temporary_model():
+    ''' Create and destroy a temporary Juju model named cdk-build-upgrade-*.
+
+    This is an async context, to be used within an `async with` statement.
+    '''
     controller = Controller()
     await controller.connect_current()
-    model_name = "cdk-build-upgrade-%d" % random.randint(0, 10000)
+    model_name = 'cdk-build-upgrade-%d' % random.randint(0, 10000)
     model = await controller.add_model(model_name)
     try:
         await yield_(model)
@@ -25,6 +29,7 @@ def assert_no_unit_errors(model):
 
 
 def all_units_ready(model):
+    ''' Returns True if all units are 'active' and 'idle', False otherwise. '''
     for unit in model.units.values():
         if unit.data['workload-status']['current'] != 'active':
             return False
@@ -34,8 +39,13 @@ def all_units_ready(model):
 
 
 async def wait_for_ready(model):
-    """ Wait until all units are 'active' and 'idle'. """
-    # FIXME: It's possible this might not handle subordinates properly
+    ''' Wait until all units are 'active' and 'idle'. '''
+    # FIXME: We might need to wait for more than just unit status.
+    #
+    # Subordinate units, for example, don't come into existence until after the
+    # principal unit has settled.
+    #
+    # If you see problems where this didn't wait long enough, it's probably that.
     while not all_units_ready(model):
         assert_no_unit_errors(model)
         await asyncio.sleep(1)
@@ -43,10 +53,11 @@ async def wait_for_ready(model):
 
 
 def assert_healthy(model):
+    ''' Assert that the current deployment is healthy. '''
     assert_no_unit_errors(model)
     expected_messages = {
-      "kubernetes-master": "Kubernetes master running.",
-      "kubernetes-worker": "Kubernetes worker running."
+      'kubernetes-master': 'Kubernetes master running.',
+      'kubernetes-worker': 'Kubernetes worker running.'
     }
     for app, message in expected_messages.items():
         for unit in model.applications[app].units:

--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -53,16 +53,3 @@ async def wait_for_ready(model):
         assert_no_unit_errors(model)
         assert loop.time() < deadline
         await asyncio.sleep(1)
-    assert_no_unit_errors(model)
-
-
-def assert_healthy(model):
-    ''' Assert that the current deployment is healthy. '''
-    assert_no_unit_errors(model)
-    expected_messages = {
-        'kubernetes-master': 'Kubernetes master running.',
-        'kubernetes-worker': 'Kubernetes worker running.'
-    }
-    for app, message in expected_messages.items():
-        for unit in model.applications[app].units:
-            assert unit.data['workload-status']['message'] == message

--- a/tests/upgrade-tests/validation.py
+++ b/tests/upgrade-tests/validation.py
@@ -1,0 +1,28 @@
+from utils import assert_no_unit_errors
+
+
+async def validate_all(model):
+    validate_status_messages(model)
+    await validate_microbot(model)
+    assert_no_unit_errors(model)
+
+
+def validate_status_messages(model):
+    ''' Validate that the status messages are correct. '''
+    expected_messages = {
+        'kubernetes-master': 'Kubernetes master running.',
+        'kubernetes-worker': 'Kubernetes worker running.'
+    }
+    for app, message in expected_messages.items():
+        for unit in model.applications[app].units:
+            assert unit.data['workload-status']['message'] == message
+
+
+async def validate_microbot(model):
+    ''' Validate the microbot action '''
+    unit = model.applications['kubernetes-worker'].units[0]
+    action = await unit.run_action('microbot', replicas=3)
+    await action.wait()
+    assert action.status == 'completed'
+    # TODO: wait for pods running
+    # TODO: test that we can reach the ingress endpoint


### PR DESCRIPTION
This is a new standalone test suite, using pytest and libjuju, for doing upgrade testing against CDK.

The tests follow this pattern:
1. Deploy initial bundle
2. Upgrade the deployment in some way (charms or snaps)
3. Assert that the deployment is healthy

I'm still thinking about step 3, the health check, and what it should look like. It's pretty weak for now but I intend to improve it.