### PR TITLE
Fix error check failing because 'juju-status' does not exist

### DIFF
--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -41,10 +41,11 @@ async def temporary_model():
 def assert_no_unit_errors(model):
     for unit in model.units.values():
         workload_status = unit.data['workload-status']['current']
-        juju_status = unit.data['juju-status']['current']
         assert workload_status != 'error'
-        assert juju_status != 'failed'
-        assert juju_status != 'lost'
+        if 'juju-status' in unit.data:
+            juju_status = unit.data['juju-status']['current']
+            assert juju_status != 'failed'
+            assert juju_status != 'lost'
 
 
 def all_units_ready(model):

--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -48,9 +48,9 @@ def assert_no_unit_errors(model):
 def all_units_ready(model):
     ''' Returns True if all units are 'active' and 'idle', False otherwise. '''
     for unit in model.units.values():
-        if unit.data['workload-status']['current'] != 'active':
+        if unit.workload_status != 'active':
             return False
-        if unit.data['agent-status']['current'] != 'idle':
+        if unit.agent_status != 'idle':
             return False
     return True
 

--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -40,12 +40,9 @@ async def temporary_model():
 
 def assert_no_unit_errors(model):
     for unit in model.units.values():
-        workload_status = unit.data['workload-status']['current']
-        assert workload_status != 'error'
-        if 'juju-status' in unit.data:
-            juju_status = unit.data['juju-status']['current']
-            assert juju_status != 'failed'
-            assert juju_status != 'lost'
+        assert unit.workload_status != 'error'
+        assert unit.agent_status != 'failed'
+        assert unit.agent_status != 'lost'
 
 
 def all_units_ready(model):

--- a/tests/upgrade-tests/validation.py
+++ b/tests/upgrade-tests/validation.py
@@ -16,7 +16,7 @@ def validate_status_messages(model):
     }
     for app, message in expected_messages.items():
         for unit in model.applications[app].units:
-            assert unit.data['workload-status']['message'] == message
+            assert unit.workload_status_message == message
 
 
 async def validate_snap_versions(model):


### PR DESCRIPTION
Sometimes the data comes back with no `'juju-status'` key.

I haven't tested this fix yet, but will kick off a test and report back on Monday.