### PR TITLE
Enable pytest assert rewrites for utils.py and validation.py

### DIFF
--- a/tests/upgrade-tests/rewrite_asserts.py
+++ b/tests/upgrade-tests/rewrite_asserts.py
@@ -1,0 +1,7 @@
+import pytest
+
+# This file needs to be imported before any of the modules specified below.
+# Otherwise, we won't get good assert output from pytest
+
+pytest.register_assert_rewrite('utils')
+pytest.register_assert_rewrite('validation')

--- a/tests/upgrade-tests/test_deploy.py
+++ b/tests/upgrade-tests/test_deploy.py
@@ -1,4 +1,5 @@
 import pytest
+import rewrite_asserts
 from utils import temporary_model, wait_for_ready
 from validation import validate_all
 

--- a/tests/upgrade-tests/test_upgrade_charms.py
+++ b/tests/upgrade-tests/test_upgrade_charms.py
@@ -1,4 +1,5 @@
 import pytest
+import rewrite_asserts
 from utils import temporary_model, wait_for_ready
 from validation import validate_all
 

--- a/tests/upgrade-tests/test_upgrade_snaps.py
+++ b/tests/upgrade-tests/test_upgrade_snaps.py
@@ -1,4 +1,5 @@
 import pytest
+import rewrite_asserts
 from utils import temporary_model, wait_for_ready
 from validation import validate_all
 


### PR DESCRIPTION
Normally, pytest only rewrites asserts in test_*.py files.

This enables assert rewriting for utils.py and validation.py as well.

Before:
```
>                   assert snap_version.startswith(track + '.')
E                   AssertionError
```

After:
```
>                   assert snap_version.startswith(track + '.')
E                   AssertionError: assert False
E                    +  where False = <built-in method startswith of str object at 0x7f53cbddedc0>(('stable' + '.'))
E                    +    where <built-in method startswith of str object at 0x7f53cbddedc0> = '1.6.2'.startswith
```

Not the prettiest thing ever, but it does show us that snap_version='1.6.2' and track='stable' -- info we otherwise would not have had.