### PR TITLE
Skip snap validation if no track is specified in config

### DIFF
--- a/tests/upgrade-tests/validation.py
+++ b/tests/upgrade-tests/validation.py
@@ -41,6 +41,11 @@ async def validate_snap_versions(model):
         app = model.applications[app_name]
         config = await app.get_config()
         channel = config['channel']['value']
+        if '/' not in channel:
+            message = 'validate_snap_versions: skipping %s, channel=%s'
+            message = message % (app_name, channel)
+            print(message)
+            continue
         track = channel.split('/')[0]
         for unit in app.units:
             action = await unit.run('snap list')


### PR DESCRIPTION
This was causing problems when kubernetes-master or kubernetes-worker were configured with channel='stable', as opposed to e.g. channel='1.6/stable'

We can skip this validation in that case -- pulling the snaps from 'stable' could give us pretty much any version, so there's not much to validate there.