### PR TITLE
Set global log level to DEBUG

### DIFF
--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -2,10 +2,15 @@ import asyncio
 import json
 import random
 import sys
+import logging
 from asyncio_extras import async_contextmanager
 from async_generator import yield_
 from juju.controller import Controller
 from juju.model import Model
+
+
+# Get verbose output from libjuju
+logging.basicConfig(level=logging.DEBUG)
 
 
 def dump_model_info(model):


### PR DESCRIPTION
We had a test run stall for 19 hours before I finally killed it. No useful output on termination.

This enables DEBUG log level for libjuju and friends. I'll update the job to run pytest with the `-s` flag as well so it doesn't capture stdout.