### PR TITLE
Bump upgrade test time limit to 1 hour

### DIFF
--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -65,7 +65,7 @@ def timeout_for_current_task(timeout):
 
 
 @async_contextmanager
-async def temporary_model(timeout=1800):
+async def temporary_model(timeout=3600):
     ''' Create and destroy a temporary Juju model named cdk-build-upgrade-*.
 
     This is an async context, to be used within an `async with` statement.


### PR DESCRIPTION
Had another test timeout. The blocker was kubernetes-master still "Waiting for kube-system pods", but it's not clear with the current output if it was stuck there or if it just didn't have enough time.

Let's just bump it up to 1 hour for now. I'd say if we still see failures after that, then we're probably well into "something went wrong" territory.