### PR TITLE
Add validator for kubelet anonymous auth disabled

### DIFF
--- a/tests/upgrade-tests/install-deps.sh
+++ b/tests/upgrade-tests/install-deps.sh
@@ -6,5 +6,5 @@ set -eux
 
 sudo apt update
 sudo apt install -y python3-pip
-sudo pip3 install -U pytest pytest-asyncio asyncio_extras juju
+sudo pip3 install -U pytest pytest-asyncio asyncio_extras juju requests
 sudo snap install conjure-up --classic

--- a/tests/upgrade-tests/utils.py
+++ b/tests/upgrade-tests/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import json
 import random
 import sys
@@ -116,3 +117,12 @@ async def wait_for_ready(model):
     while not all_units_ready(model):
         assert_no_unit_errors(model)
         await asyncio.sleep(1)
+
+
+def asyncify(f):
+    ''' Convert a blocking function into a coroutine '''
+    async def wrapper(*args, **kwargs):
+        loop = asyncio.get_event_loop()
+        partial = functools.partial(f, *args, **kwargs)
+        return await loop.run_in_executor(None, partial)
+    return wrapper

--- a/tests/upgrade-tests/validation.py
+++ b/tests/upgrade-tests/validation.py
@@ -1,10 +1,12 @@
-from utils import assert_no_unit_errors
+import requests
+from utils import assert_no_unit_errors, asyncify
 
 
 async def validate_all(model):
     validate_status_messages(model)
     await validate_snap_versions(model)
     await validate_microbot(model)
+    await validate_kubelet_anonymous_auth_disabled(model)
     assert_no_unit_errors(model)
 
 
@@ -71,3 +73,14 @@ async def validate_microbot(model):
     assert action.status == 'completed'
     # TODO: wait for pods running
     # TODO: test that we can reach the ingress endpoint
+
+
+async def validate_kubelet_anonymous_auth_disabled(model):
+    ''' Validate that kubelet has anonymous auth disabled '''
+    units = model.applications['kubernetes-worker'].units
+    for unit in units:
+        await unit.run('open-port 10250')
+        address = unit.public_address
+        url = 'https://%s:10250/runningpods/' % address
+        response = await asyncify(requests.get)(url, verify=False)
+        assert response.status_code == 401  # Unauthorized


### PR DESCRIPTION
This tests https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/314 by verifying that kubelet returns a 401 Unauthorized response to anonymous clients.