### PR TITLE
Update run-bundle-tests to test 1.7/stable snaps by default

### DIFF
--- a/tests/run-bundle-tests.sh
+++ b/tests/run-bundle-tests.sh
@@ -15,7 +15,7 @@ set -eux
 TEST_BUNDLES="${TEST_BUNDLES:-canonical-kubernetes}"
 TEST_CONTROLLERS="${TEST_CONTROLLERS:-$(juju switch | cut -d ':' -f 1)}"
 TEST_BUNDLE_CHANNEL="${TEST_BUNDLE_CHANNEL:-edge}"
-TEST_SNAP_CHANNEL="${TEST_SNAP_CHANNEL:-1.6/edge}"
+TEST_SNAP_CHANNEL="${TEST_SNAP_CHANNEL:-1.7/stable}"
 
 rm -rf results
 


### PR DESCRIPTION
No fun testing 1.6 anymore!

Having to bump a default here kinda sucks, so we might want to revisit this later.