### PR TITLE
Get juju debug logs on test failure

### DIFF
--- a/tests/upgrade-tests/conftest.py
+++ b/tests/upgrade-tests/conftest.py
@@ -17,7 +17,7 @@ def log_dir(request):
     path = os.path.join(
         'logs',
         request.module.__name__,
-        request.node.name
+        request.node.name.replace('/', '_')
     )
     os.makedirs(path)
     return path

--- a/tests/upgrade-tests/conftest.py
+++ b/tests/upgrade-tests/conftest.py
@@ -1,0 +1,25 @@
+# This is a special file imported by pytest for any test file.
+# Fixtures and stuff go here.
+
+import os
+import pytest
+import shutil
+from contextlib import suppress
+
+pytest.register_assert_rewrite('utils')
+pytest.register_assert_rewrite('validation')
+
+with suppress(FileNotFoundError):
+    shutil.rmtree('logs')
+
+
+@pytest.fixture
+def log_dir(request):
+    """ Fixture directory for storing arbitrary test logs. """
+    path = os.path.join(
+        'logs',
+        request.module.__name__,
+        request.node.name
+    )
+    os.makedirs(path)
+    return path

--- a/tests/upgrade-tests/conftest.py
+++ b/tests/upgrade-tests/conftest.py
@@ -4,13 +4,11 @@
 import os
 import pytest
 import shutil
-from contextlib import suppress
 
 pytest.register_assert_rewrite('utils')
 pytest.register_assert_rewrite('validation')
 
-with suppress(FileNotFoundError):
-    shutil.rmtree('logs')
+shutil.rmtree('logs', ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/upgrade-tests/rewrite_asserts.py
+++ b/tests/upgrade-tests/rewrite_asserts.py
@@ -1,7 +1,0 @@
-import pytest
-
-# This file needs to be imported before any of the modules specified below.
-# Otherwise, we won't get good assert output from pytest
-
-pytest.register_assert_rewrite('utils')
-pytest.register_assert_rewrite('validation')

--- a/tests/upgrade-tests/test_deploy.py
+++ b/tests/upgrade-tests/test_deploy.py
@@ -1,5 +1,4 @@
 import pytest
-import rewrite_asserts
 from utils import temporary_model, wait_for_ready, conjureup, deploy_e2e
 from validation import validate_all
 
@@ -9,10 +8,11 @@ test_cases = [
     ('containers', 'canonical-kubernetes', 'edge',    '1.7/stable'),
 ]
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize('namespace,bundle,channel,snap_channel', test_cases)
-async def test_deploy(namespace, bundle, channel, snap_channel):
-    async with temporary_model() as model:
+async def test_deploy(namespace, bundle, channel, snap_channel, log_dir):
+    async with temporary_model(log_dir) as model:
         await conjureup(model, namespace, bundle, channel, snap_channel)
         await deploy_e2e(model, channel, snap_channel)
         await wait_for_ready(model)

--- a/tests/upgrade-tests/test_upgrade_charms.py
+++ b/tests/upgrade-tests/test_upgrade_charms.py
@@ -1,5 +1,4 @@
 import pytest
-import rewrite_asserts
 from utils import temporary_model, wait_for_ready, conjureup, deploy_e2e
 from validation import validate_all
 
@@ -12,8 +11,8 @@ test_cases = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('namespace,bundle,from_channel,to_channel,snap_channel', test_cases)
-async def test_upgrade_charms(namespace, bundle, from_channel, to_channel, snap_channel):
-    async with temporary_model() as model:
+async def test_upgrade_charms(namespace, bundle, from_channel, to_channel, snap_channel, log_dir):
+    async with temporary_model(log_dir) as model:
         await conjureup(model, namespace, bundle, from_channel, snap_channel)
         await wait_for_ready(model)
         for app in model.applications.values():

--- a/tests/upgrade-tests/test_upgrade_snaps.py
+++ b/tests/upgrade-tests/test_upgrade_snaps.py
@@ -1,5 +1,4 @@
 import pytest
-import rewrite_asserts
 from utils import temporary_model, wait_for_ready, conjureup, deploy_e2e
 from validation import validate_all
 
@@ -20,8 +19,8 @@ async def set_snap_channel(model, channel):
 @pytest.mark.asyncio
 @pytest.mark.parametrize('namespace,bundle,charm_channel,from_channel,to_channel',
                          test_cases)
-async def test_upgrade_snaps(namespace, bundle, charm_channel, from_channel, to_channel):
-    async with temporary_model() as model:
+async def test_upgrade_snaps(namespace, bundle, charm_channel, from_channel, to_channel, log_dir):
+    async with temporary_model(log_dir) as model:
         await conjureup(model, namespace, bundle, charm_channel, from_channel)
         await wait_for_ready(model)
         await set_snap_channel(model, to_channel)


### PR DESCRIPTION
This updates our integration tests to include juju debug logs on test failure.

Rather than dump to stdout, I've added infrastructure for test-specific log directories that we can dump files to.

These changes are not fully tested.