### PR TITLE
Add test_live_model.py

### DIFF
--- a/integration-tests/test_live_model.py
+++ b/integration-tests/test_live_model.py
@@ -1,0 +1,17 @@
+# Tests an existing deployment.
+# Assumes that a CDK deployment exists in the current Juju model.
+
+import pytest
+from juju.model import Model
+from utils import captured_fail_logs
+from validation import validate_all
+
+@pytest.mark.asyncio
+async def test_live_model(log_dir):
+    model = Model()
+    try:
+        await model.connect_current()
+        async with captured_fail_logs(model, log_dir):
+            await validate_all(model)
+    finally:
+        await model.disconnect()


### PR DESCRIPTION
To aid in developing validators quickly.

This wouldn't be run in CI at all, but would be usable by devs when developing validators. Gives us a way to rerun them without having to wait for a whole new fresh deployment.

I'm on the fence about this one, and it needs testing, but figured I'd throw a PR up for opinions. Is this valuable to us?