### PR TITLE
add dashboard test

### DIFF
--- a/integration-tests/test_charms.py
+++ b/integration-tests/test_charms.py
@@ -21,7 +21,7 @@ async def test_deploy(bundle, log_dir):
         # await conjureup(model, namespace, bundle, channel)
         await juju_deploy(model, namespace, bundle, channel)
         await deploy_e2e(model, channel)
-        await validate_all(model)
+        await validate_all(model, log_dir)
 
 
 @pytest.mark.asyncio
@@ -32,7 +32,7 @@ async def test_upgrade(bundle, log_dir):
         await juju_deploy(model, namespace, bundle, channel)
         await upgrade_charms(model, channel)
         await deploy_e2e(model, channel)
-        await validate_all(model)
+        await validate_all(model, log_dir)
 
 
 @pytest.mark.asyncio

--- a/integration-tests/test_live_model.py
+++ b/integration-tests/test_live_model.py
@@ -12,6 +12,6 @@ async def test_live_model(log_dir):
     try:
         await model.connect_current()
         async with captured_fail_logs(model, log_dir):
-            await validate_all(model)
+            await validate_all(model, log_dir)
     finally:
         await model.disconnect()

--- a/integration-tests/test_upgrade_snaps.py
+++ b/integration-tests/test_upgrade_snaps.py
@@ -28,4 +28,4 @@ async def test_upgrade_snaps(namespace, bundle, charm_channel, from_channel, to_
             await action.wait()
             assert action.status == 'completed'
         await deploy_e2e(model, charm_channel, to_channel)
-        await validate_all(model)
+        await validate_all(model, log_dir)

--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -82,7 +82,7 @@ async def validate_microbot(model):
     assert action.status == 'completed'
     for i in range(60):
         resp = await asyncify(requests.get)('http://' + action.data['results']['address'])
-        if resp.ok:
+        if resp.status_code == 200:
             return
         await asyncio.sleep(1)
     raise MicrobotError('Microbot failed to start.')
@@ -100,15 +100,13 @@ async def validate_dashboard(model, log_dir):
     password = config['users'][0]['user']['password']
     auth = requests.auth.HTTPBasicAuth(user, password)
     resp = await asyncify(requests.get)(url, auth=auth, verify=False)
-    assert resp.ok is True
+    assert resp.status_code == 200
     url = '%s/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/api/v1/workload/default?filterBy=&itemsPerPage=10&page=1&sortBy=d,creationTimestamp'
     url %= config['clusters'][0]['cluster']['server']
     resp = await asyncify(requests.get)(url, auth=auth, verify=False)
-    assert resp.ok is True
+    assert resp.status_code == 200
     data = resp.json()
-    assert len(data['podList']['pods'][0]['metrics']['cpuUsageHistory']) > 0
-    assert len(data['podList']['pods'][0]['metrics']['memoryUsageHistory']) > 0
-    with open(os.path.join(log_dir, 'dashboard.json'), 'w') as f:
+    with open(os.path.join(log_dir, 'dashboard.yaml'), 'w') as f:
         yaml.dump(data, f, default_flow_style=False)
 
 

--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -1,14 +1,20 @@
 import asyncio
+import os
 import requests
+import yaml
+
+from tempfile import NamedTemporaryFile
+
 from utils import assert_no_unit_errors, asyncify, wait_for_ready
 
 
-async def validate_all(model):
+async def validate_all(model, log_dir):
     validate_status_messages(model)
     await validate_snap_versions(model)
     await validate_microbot(model)
     await validate_kubelet_anonymous_auth_disabled(model)
     await validate_e2e_tests(model)
+    await validate_dashboard(model, log_dir)
     assert_no_unit_errors(model)
 
 
@@ -75,11 +81,35 @@ async def validate_microbot(model):
     await action.wait()
     assert action.status == 'completed'
     for i in range(60):
-        resp = requests.get('http://' + action.data['results']['address'])
+        resp = await asyncify(requests.get)('http://' + action.data['results']['address'])
         if resp.ok:
             return
         await asyncio.sleep(1)
     raise MicrobotError('Microbot failed to start.')
+
+
+async def validate_dashboard(model, log_dir):
+    ''' Validate that the dashboard is operational '''
+    unit = model.applications['kubernetes-master'].units[0]
+    with NamedTemporaryFile() as f:
+        await unit.scp_from('config', f.name)
+        with open(f.name, 'r') as stream:
+            config = yaml.load(stream)
+    url = config['clusters'][0]['cluster']['server']
+    user = config['users'][0]['user']['username']
+    password = config['users'][0]['user']['password']
+    auth = requests.auth.HTTPBasicAuth(user, password)
+    resp = await asyncify(requests.get)(url, auth=auth, verify=False)
+    assert resp.ok is True
+    url = '%s/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/api/v1/workload/default?filterBy=&itemsPerPage=10&page=1&sortBy=d,creationTimestamp'
+    url %= config['clusters'][0]['cluster']['server']
+    resp = await asyncify(requests.get)(url, auth=auth, verify=False)
+    assert resp.ok is True
+    data = resp.json()
+    assert len(data['podList']['pods'][0]['metrics']['cpuUsageHistory']) > 0
+    assert len(data['podList']['pods'][0]['metrics']['memoryUsageHistory']) > 0
+    with open(os.path.join(log_dir, 'dashboard.json'), 'w') as f:
+        yaml.dump(data, f, default_flow_style=False)
 
 
 async def validate_kubelet_anonymous_auth_disabled(model):


### PR DESCRIPTION
This checks that:
 - the dashboard url returns 200
 - a call to the dashboard api returns 200
 - ~there are metrics returned in the api call~

~The metrics are checked by making sure there's >0 cpu and memory data points. This is a little risky because there simply may not be any yet. To address this, I've placed the dashboard check after the e2e testing.~

NVM, metrics checking is too flaky. Getting rid of it for now.