### PR TITLE
Disable elastic bundle build

### DIFF
--- a/charms/build-and-release-bundles.sh
+++ b/charms/build-and-release-bundles.sh
@@ -14,13 +14,14 @@ release-bundle() {
 
 bundle/bundle -o ./bundles/cdk-flannel -c edge k8s/cdk cni/flannel
 bundle/bundle -o ./bundles/core-flannel -c edge k8s/core cni/flannel
-bundle/bundle -o ./bundles/cdk-flannel-elastic -c edge k8s/cdk cni/flannel monitor/elastic
+# Disabled elastic until the elasticsearch charm is back in edge
+# bundle/bundle -o ./bundles/cdk-flannel-elastic -c edge k8s/cdk cni/flannel monitor/elastic
 bundle/bundle -o ./bundles/cdk-calico -c edge k8s/cdk cni/calico
 bundle/bundle -o ./bundles/cdk-canal -c edge k8s/cdk cni/canal
 
 release-bundle ./bundles/cdk-flannel cs:~containers/bundle/canonical-kubernetes
 release-bundle ./bundles/core-flannel cs:~containers/bundle/kubernetes-core
-release-bundle ./bundles/cdk-flannel-elastic cs:~containers/bundle/canonical-kubernetes-elastic
+# release-bundle ./bundles/cdk-flannel-elastic cs:~containers/bundle/canonical-kubernetes-elastic
 release-bundle ./bundles/cdk-calico cs:~containers/bundle/kubernetes-calico
 release-bundle ./bundles/cdk-canal cs:~containers/bundle/canonical-kubernetes-canal
 


### PR DESCRIPTION
Our build-and-release-all-charms-and-bundles job currently fails with this:

```
+ bundle/bundle -o ./bundles/cdk-flannel-elastic -c edge k8s/cdk cni/flannel monitor/elastic
Processing fragment k8s/cdk...
Processing fragment cni/flannel...
Processing fragment monitor/elastic...
Traceback (most recent call last):
  File "bundle/bundle", line 204, in <module>
    main()
  File "bundle/bundle", line 175, in main
    bundle = version_bundle(bundle, args.channel)
  File "bundle/bundle", line 122, in version_bundle
    meta = [meta[k] for k in meta][0]
IndexError: list index out of range
```

This is happening because the newly promulgated elasticsearch charm hasn't been released to edge. We need a better fix, but for now, let's disable it so we get our builds over the weekend.