### PR TITLE
Add bundle as cli so we can override it when on lxd

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -21,3 +21,13 @@ def log_dir(request):
     )
     os.makedirs(path)
     return path
+
+
+def pytest_addoption(parser):
+    parser.addoption("--bundle", action="store", default=None,
+        help="bundle: specify the bundle under containers namespace")
+
+
+@pytest.fixture
+def bundle_override(request):
+    return request.config.getoption("--bundle")

--- a/integration-tests/test_cdk.py
+++ b/integration-tests/test_cdk.py
@@ -16,7 +16,9 @@ bundles = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('bundle', bundles)
-async def test_deploy(bundle, log_dir):
+async def test_deploy(bundle, log_dir, bundle_override):
+    if bundle_override:
+        bundle = bundle_override
     async with temporary_model(log_dir) as model:
         # await conjureup(model, namespace, bundle, charm_channel,
         #                 snap_channel)
@@ -28,7 +30,9 @@ async def test_deploy(bundle, log_dir):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('bundle', bundles)
-async def test_upgrade(bundle, log_dir):
+async def test_upgrade(bundle, log_dir, bundle_override):
+    if bundle_override:
+        bundle = bundle_override
     async with temporary_model(log_dir) as model:
         # await conjureup(model, namespace, bundle, 'stable')
         await juju_deploy(model, namespace, bundle, 'stable')
@@ -39,6 +43,6 @@ async def test_upgrade(bundle, log_dir):
 
 
 @pytest.mark.asyncio
-async def test_bundletester(log_dir):
+async def test_bundletester(log_dir, bundle_override):
     await run_bundletester(namespace, log_dir, channel=charm_channel,
                            snap_channel=snap_channel)


### PR DESCRIPTION
On our CI we want to run the full set of tests on lxd, however, the calico & canal bundles will not deploy there. We need a way to override the set of bundles we run the tests against. With this PR for lxd we can do:

```
pytest -s test_cdk.py --bundle canonical-kubernetes
```