### PR TITLE
Check for new release. Build snaps and release to edge and candidate.

### DIFF
--- a/snaps/build-and-release-snaps-on-new-release.sh
+++ b/snaps/build-and-release-snaps-on-new-release.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+set -eux
+
 KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
 # LAST_RELEASE_FILE keeps the last release we did.
 LAST_RELEASE_FILE="/var/tmp/last_k8s_patch_release"
@@ -14,7 +16,6 @@ function check_for_release {
     if [ "$LAST_RELEASED" != "$KUBE_VERSION" ]
     then
       echo "New release ($KUBE_VERSION) detected."
-      echo "$KUBE_VERSION" > $LAST_RELEASE_FILE
       trigger='yes'
     else
       echo "No new release detected. Latest release is $LAST_RELEASED."
@@ -36,12 +37,12 @@ then
   # Build the snaps and push to edge
   $scripts_path/build-and-release-k8s-snaps.sh
 
-  if [ "$?" == 0 ]
-  then
-    # Promote snaps from edge to candidate
-    version=${KUBE_VERSION:1:3}
-    export PROMOTE_FROM="$version/edge"
-    export PROMOTE_TO="$version/beta $version/candidate"
-    $scripts_path/promote-snaps.sh
-  fi
+  # Promote snaps from edge to candidate
+  version=${KUBE_VERSION:1:3}
+  export PROMOTE_FROM="$version/edge"
+  export PROMOTE_TO="$version/beta $version/candidate"
+  $scripts_path/promote-snaps.sh
+
+  # We are done with promoting the snaps. Lets mark the release.
+  echo "$KUBE_VERSION" > $LAST_RELEASE_FILE
 fi

--- a/snaps/build-and-release-snaps-on-new-release.sh
+++ b/snaps/build-and-release-snaps-on-new-release.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+
+KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
+# LAST_RELEASE_FILE keeps the last release we did.
+LAST_RELEASE_FILE="/var/tmp/last_k8s_patch_release"
+
+
+function check_for_release {
+  trigger='no'
+  if [ -f $LAST_RELEASE_FILE ]
+  then
+    LAST_RELEASED=`cat $LAST_RELEASE_FILE`
+    if [ "$LAST_RELEASED" != "$KUBE_VERSION" ]
+    then
+      echo "New release ($KUBE_VERSION) detected."
+      echo "$KUBE_VERSION" > $LAST_RELEASE_FILE
+      trigger='yes'
+    else
+      echo "No new release detected. Latest release is $LAST_RELEASED."
+      trigger='no'
+    fi
+  else
+    echo "Bootstrapping trigger with kubernetes version $KUBE_VERSION."
+    echo "Releases following $KUBE_VERSION will trigger the snap release process."
+    echo "$KUBE_VERSION" > $LAST_RELEASE_FILE
+    trigger='init'
+  fi
+}
+
+
+check_for_release
+if [ "$trigger" == 'yes' ]
+then
+  scripts_path=$(dirname "$0")
+  # Build the snaps and push to edge
+  $scripts_path/build-and-release-k8s-snaps.sh
+
+  if [ "$?" == 0 ]
+  then
+    # Promote snaps from edge to candidate
+    version=${KUBE_VERSION:1:3}
+    export PROMOTE_FROM="$version/edge"
+    export PROMOTE_TO="$version/candidate"
+    export FAKE_PROMOTE="no"
+    $scripts_path/promote-snaps.sh
+  fi
+fi

--- a/snaps/build-and-release-snaps-on-new-release.sh
+++ b/snaps/build-and-release-snaps-on-new-release.sh
@@ -41,8 +41,7 @@ then
     # Promote snaps from edge to candidate
     version=${KUBE_VERSION:1:3}
     export PROMOTE_FROM="$version/edge"
-    export PROMOTE_TO="$version/candidate"
-    export FAKE_PROMOTE="no"
+    export PROMOTE_TO="$version/beta $version/candidate"
     $scripts_path/promote-snaps.sh
   fi
 fi

--- a/snaps/promote-snaps.sh
+++ b/snaps/promote-snaps.sh
@@ -7,7 +7,6 @@ set -eu
 # snaps/promote-snaps.sh
 
 SNAPS="kubectl kube-apiserver kube-controller-manager kube-scheduler kubelet kube-proxy cdk-addons kubeadm kubefed kubernetes-test"
-FAKE_PROMOTE="${FAKE_PROMOTE:-yes}"
 
 echo PROMOTE_FROM="$PROMOTE_FROM"
 echo PROMOTE_TO="$PROMOTE_TO"
@@ -15,21 +14,12 @@ echo SNAPS="$SNAPS"
 
 . utils/retry.sh
 
-if [ "${FAKE_PROMOTE}" = "yes" ]
-then
-  echo "NOTE: Not actually releasing. Please look over this output carefully and run it manually.\n"
-fi
-
 for snap in $SNAPS; do
   revisions="$(snapcraft revisions $snap | grep " ${PROMOTE_FROM}\*" | cut -d " " -f 1)"
   for rev in $revisions; do
     for target in $PROMOTE_TO; do
-      if [ "${FAKE_PROMOTE}" = "yes" ]
-      then
-        echo snapcraft release $snap $rev $target
-      else
-        retry snapcraft release $snap $rev $target
-      fi
+      echo snapcraft release $snap $rev $target
+      retry snapcraft release $snap $rev $target
     done
   done
 done

--- a/snaps/promote-snaps.sh
+++ b/snaps/promote-snaps.sh
@@ -7,18 +7,29 @@ set -eu
 # snaps/promote-snaps.sh
 
 SNAPS="kubectl kube-apiserver kube-controller-manager kube-scheduler kubelet kube-proxy cdk-addons kubeadm kubefed kubernetes-test"
+FAKE_PROMOTE="${FAKE_PROMOTE:-yes}"
 
 echo PROMOTE_FROM="$PROMOTE_FROM"
 echo PROMOTE_TO="$PROMOTE_TO"
 echo SNAPS="$SNAPS"
 
-echo "NOTE: Not actually releasing. Please look over this output carefully and run it manually.\n"
+. utils/retry.sh
+
+if [ "${FAKE_PROMOTE}" = "yes" ]
+then
+  echo "NOTE: Not actually releasing. Please look over this output carefully and run it manually.\n"
+fi
 
 for snap in $SNAPS; do
   revisions="$(snapcraft revisions $snap | grep " ${PROMOTE_FROM}\*" | cut -d " " -f 1)"
   for rev in $revisions; do
     for target in $PROMOTE_TO; do
-      echo snapcraft release $snap $rev $target
+      if [ "${FAKE_PROMOTE}" = "yes" ]
+      then
+        echo snapcraft release $snap $rev $target
+      else
+        retry snapcraft release $snap $rev $target
+      fi
     done
   done
 done


### PR DESCRIPTION
This PR adds build-and-release-snaps-on-new-release.sh that is meant to be triggered periodically from our CI. This script will scan for new stable releases and will build the snaps and push them to edge and candidate using the respective scripts.

The promote snaps script is patched to allow to actually promote the snaps instead of faking it.