### PR TITLE
Use CDK for e2e tests and error on gubernator errors

### DIFF
--- a/tests/deploy-test-bundle.sh
+++ b/tests/deploy-test-bundle.sh
@@ -10,7 +10,7 @@ echo "${0} started at `date`."
 # First argument is the model namme for this build.
 MODEL=${1:-"model-is-undefined"}
 # The second argument is the bundle name.
-BUNDLE=${2:-"kubernetes-core"}
+BUNDLE=${2:-"canonical-kubernetes"}
 # Create a model just for this run of the tests.
 juju add-model ${MODEL}
 # Set test mode on the deployment so we dont bloat charm-store deployment count
@@ -19,8 +19,6 @@ juju model-config -m ${MODEL} test-mode=1
 # Deploy the kubernetes bundle.
 juju deploy ${BUNDLE}
 # TODO Check for a second worker, the bundle could already define one.
-# Add one more kubernetes node to the cluster.
-juju add-unit kubernetes-worker
 # TODO Check for the e2e charm, the bundle could already define one.
 # Deploy the e2e charm and make the relations.
 juju deploy cs:~containers/kubernetes-e2e

--- a/tests/e2e-gubernator.sh
+++ b/tests/e2e-gubernator.sh
@@ -16,7 +16,7 @@ MODEL=${BUILD_TAG:-"default-model"}
 # Set the output directory to store the results.
 OUTPUT_DIRECTORY=${SCRIPT_DIRECTORY}/artifacts
 # Set the bundle name to use.
-BUNDLE=kubernetes-core
+BUNDLE=canonical-kubernetes
 
 # Set the Juju envrionment variables for this script.
 export JUJU_REPOSITORY=${SCRIPT_DIRECTORY}/build/charms

--- a/tests/run-e2e-tests.sh
+++ b/tests/run-e2e-tests.sh
@@ -18,7 +18,12 @@ ACTION_ID=$(juju run-action kubernetes-e2e/0 test | cut -d " " -f 5)
 # Wait 2 hour for the action to complete.
 juju show-action-output --wait=2h ${ACTION_ID}
 # Print out the action result.
-juju show-action-output ${ACTION_ID}
+outcome=`juju show-action-output ${ACTION_ID}`
+echo $outcome
+if [[ "$outcome" == *"failed"* ]]
+then
+  exit 1
+fi
 
 # Download results from the charm and move them to the the volume directory.
 juju scp kubernetes-e2e/0:${ACTION_ID}.log.tar.gz e2e.log.tar.gz

--- a/tests/wait-cluster-ready.sh
+++ b/tests/wait-cluster-ready.sh
@@ -12,6 +12,7 @@ source ./utilities.sh
 
 # Wait in 10 second increments for the master charm to print running in status.
 run_and_wait "juju status kubernetes-master" "Kubernetes master running." 10
+wait_for_ready
 # Print out a full juju status.
 juju status
 

--- a/utilities.sh
+++ b/utilities.sh
@@ -47,6 +47,21 @@ function run_and_wait() {
   done
 }
 
+# Wait for deployment to get ready.
+function wait_for_ready() {
+  local cmd='juju status'
+  local sleep_seconds=30
+  local start_time=`date +"%s"`
+  lines=$(${cmd} | grep  -e "waiting" -e "executing" -e "maintenance" -e "blocked" -e "error" | wc -l)
+  until (( $lines <= 0 )); do
+    # Check the time so this does not loop forever.
+    check_time ${start_time} ${MAXIMUM_WAIT_SECONDS}
+    sleep ${sleep_seconds}
+    lines=$(${cmd} | grep  -e "waiting" -e "executing" -e "maintenance" -e "blocked" -e "error" | wc -l) || true
+    # if lines == 0 then $? > 0 because wc -l got no lines. We should not return this code.
+  done
+}
+
 # A platform neutral way to get the md5 hash sum of a file.
 function md5sum_file() {
   if which md5sum > /dev/null 2>&1; then


### PR DESCRIPTION
A few fixes:
1. Gubernator jobs fail if e2e fail
2. Wait for the deployment to become ready will wait for all apps to get ready (not only kubernetes-master)
3. Use CDK and not core bundle