### PR TITLE
Cleanup before release snaps

### DIFF
--- a/snaps/build-and-release-k8s-snaps.sh
+++ b/snaps/build-and-release-k8s-snaps.sh
@@ -7,6 +7,7 @@ KUBE_ARCH="amd64"
 
 source utils/retry.sh
 
+rm -rf ./release
 git clone https://github.com/juju-solutions/release.git --branch rye/snaps --depth 1
 (cd release/snap
   make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH="$KUBE_ARCH" \
@@ -15,6 +16,7 @@ git clone https://github.com/juju-solutions/release.git --branch rye/snaps --dep
     targets="kube-controller-manager kubernetes-test"
 )
 
+rm -rf ./cdk-addons
 git clone https://github.com/juju-solutions/cdk-addons.git --depth 1
 for arch in $KUBE_ARCH; do
   (cd cdk-addons && make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH=${arch})


### PR DESCRIPTION
When a new release on the latest branch is available we do a git clone twice and this fails.

Have a look at what happened here:
https://ci.kubernetes.juju.solutions/job/build-snaps-on-new-release/44/console

We need to make sure the release and cdk-addons directories are not present before cloning the respective repos. This cleanup was done by jenkins as part of preparing the workspace. However, we now want to to make multiple builds on the same workspace so we need to do this cleanup ourselves.