### PR TITLE
Build cdk addons from release branches

### DIFF
--- a/snaps/build-and-release-k8s-snaps.sh
+++ b/snaps/build-and-release-k8s-snaps.sh
@@ -21,6 +21,7 @@ git clone https://github.com/juju-solutions/release.git --branch rye/snaps --dep
 rm -rf ./cdk-addons
 if git ls-remote --exit-code --heads https://github.com/juju-solutions/cdk-addons.git ${ADDONS_BRANCH_VERSION}
 then
+  echo "Getting cdk-addons from ${ADDONS_BRANCH_VERSION} branch."
   git clone https://github.com/juju-solutions/cdk-addons.git --branch ${ADDONS_BRANCH_VERSION} --depth 1
 else
   echo "Branch for ${ADDONS_BRANCH_VERSION} does not exist. Getting cdk-addons from master head."

--- a/snaps/build-and-release-k8s-snaps.sh
+++ b/snaps/build-and-release-k8s-snaps.sh
@@ -4,10 +4,12 @@ set -eux
 
 KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
 KUBE_ARCH="amd64"
-ADDONS_BRANCH_VERSION="release-${KUBE_VERSION:1:3}"
+
+source utilities.sh
+MAIN_VERSION=$(get_major_minor $KUBE_VERSION)
+ADDONS_BRANCH_VERSION="release-${MAIN_VERSION}"
 
 source utils/retry.sh
-source utilities.sh
 
 rm -rf ./release
 git clone https://github.com/juju-solutions/release.git --branch rye/snaps --depth 1
@@ -31,17 +33,16 @@ for arch in $KUBE_ARCH; do
   (cd cdk-addons && make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH=${arch})
 done
 
-channel=$(get_major_minor $KUBE_VERSION)
 for app in kubeadm kube-apiserver kubectl kubefed kubelet kube-proxy kube-scheduler; do
   for arch in $KUBE_ARCH; do
-    retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${arch}.snap --release ${channel}/edge
+    retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${arch}.snap --release ${MAIN_VERSION}/edge
   done
 done
 
 for app in kube-controller-manager kubernetes-test; do
-  retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_amd64.snap --release ${channel}/edge
+  retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_amd64.snap --release ${MAIN_VERSION}/edge
 done
 
 for arch in $KUBE_ARCH; do
-  retry snapcraft push cdk-addons/cdk-addons_${KUBE_VERSION:1}_${arch}.snap --release ${channel}/edge
+  retry snapcraft push cdk-addons/cdk-addons_${KUBE_VERSION:1}_${arch}.snap --release ${MAIN_VERSION}/edge
 done

--- a/snaps/build-and-release-k8s-snaps.sh
+++ b/snaps/build-and-release-k8s-snaps.sh
@@ -4,6 +4,7 @@ set -eux
 
 KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
 KUBE_ARCH="amd64"
+ADDONS_BRANCH_VERSION="release-${KUBE_VERSION:1:3}"
 
 source utils/retry.sh
 source utilities.sh
@@ -18,7 +19,13 @@ git clone https://github.com/juju-solutions/release.git --branch rye/snaps --dep
 )
 
 rm -rf ./cdk-addons
-git clone https://github.com/juju-solutions/cdk-addons.git --depth 1
+if git ls-remote --exit-code --heads https://github.com/juju-solutions/cdk-addons.git ${ADDONS_BRANCH_VERSION}
+then
+  git clone https://github.com/juju-solutions/cdk-addons.git --branch ${ADDONS_BRANCH_VERSION} --depth 1
+else
+  echo "Branch for ${ADDONS_BRANCH_VERSION} does not exist. Getting cdk-addons from master head."
+  git clone https://github.com/juju-solutions/cdk-addons.git --depth 1
+fi
 for arch in $KUBE_ARCH; do
   (cd cdk-addons && make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH=${arch})
 done


### PR DESCRIPTION
With this PR we are cheking out the branch "release-X.Y" of cdk addons when we build against X.Y.Z k8s.

If the cdk-addons branch is not there that means we are building addons for the latest k8s and we default to head master. 