### PR TITLE
Increase validate_api_extra_args timeouts

### DIFF
--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -307,22 +307,22 @@ async def validate_api_extra_args(model):
         'enable-swagger-ui=false'
     }
 
-    with timeout_for_current_task(60):
+    with timeout_for_current_task(180):
         while True:
             args_per_unit = await get_apiserver_args()
             if all(expected_args <= args for args in args_per_unit):
                 break
-            await asyncio.sleep(1)
+            await asyncio.sleep(3)
 
     original_args_config = original_config['api-extra-args']['value']
     await app.set_config({'api-extra-args': original_args_config})
 
-    with timeout_for_current_task(60):
+    with timeout_for_current_task(180):
         while True:
             new_args = await get_apiserver_args()
             if new_args == original_args:
                 break
-            await asyncio.sleep(1)
+            await asyncio.sleep(3)
 
 
 class MicrobotError(Exception):


### PR DESCRIPTION
Often validate_api_extra_args test times out. Have a look at:
https://ci.kubernetes.juju.solutions/job/build-and-release-all-charms-and-bundles/515/testReport/junit/(root)/test_cdk/test_deploy_kubernetes_core_/
https://ci.kubernetes.juju.solutions/job/build-and-release-all-charms-and-bundles/516/testReport/junit/(root)/test_cdk/test_upgrade_canonical_kubernetes_canal_/
https://ci.kubernetes.juju.solutions/job/build-and-release-all-charms-and-bundles/517/testReport/junit/(root)/test_cdk/test_deploy_canonical_kubernetes_canal_/

Was able to repro by trying this specific test many times.
