### PR TITLE
Update test_live_model to wait for ready before validation

### DIFF
--- a/integration-tests/test_live_model.py
+++ b/integration-tests/test_live_model.py
@@ -3,8 +3,9 @@
 
 import pytest
 from juju.model import Model
-from utils import captured_fail_logs
+from utils import captured_fail_logs, wait_for_ready
 from validation import validate_all
+
 
 @pytest.mark.asyncio
 async def test_live_model(log_dir):
@@ -12,6 +13,7 @@ async def test_live_model(log_dir):
     try:
         await model.connect_current()
         async with captured_fail_logs(model, log_dir):
+            await wait_for_ready(model)
             await validate_all(model, log_dir)
     finally:
         await model.disconnect()


### PR DESCRIPTION
Minor improvement to test_live_model.py. This lets you start a deployment and then run test_live_model before the deployment finishes.