### PR TITLE
Fix missing import for validate_sans

### DIFF
--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import requests
+import time
 import traceback
 import yaml
 


### PR DESCRIPTION
Fixing this error from CI:
```
    async def validate_sans(model):
        ...
>       deadline = time.time() + 60
E       NameError: name 'time' is not defined
```