### PR TITLE
Increase timeout in validate_sans

### DIFF
--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -361,12 +361,12 @@ async def validate_sans(model):
         await lb.set_config({'extra_sans': example_domain})
 
     # wait for server certs to update
-    deadline = time.time() + 60
+    deadline = time.time() + 180
     while time.time() < deadline:
         certs = await get_server_certs()
         if all(example_domain in cert for cert in certs):
             break
-        await asyncio.sleep(1)
+        await asyncio.sleep(3)
     else:
         raise TimeoutError('extra sans config did not propogate to server certs')
 
@@ -376,12 +376,12 @@ async def validate_sans(model):
         await lb.set_config({'extra_sans': ''})
 
     # verify it went away
-    deadline = time.time() + 60
+    deadline = time.time() + 180
     while time.time() < deadline:
         certs = await get_server_certs()
         if not any(example_domain in cert for cert in certs):
             break
-        await asyncio.sleep(1)
+        await asyncio.sleep(3)
     else:
         raise TimeoutError('extra sans config removal did not propogate to server certs')
 


### PR DESCRIPTION
Although I couldn't reproduce this timeout locally we have seen this timeout a few times: https://ci.kubernetes.juju.solutions/job/build-and-release-all-charms-and-bundles/541/testReport/junit/(root)/test_cdk/test_deploy_kubernetes_core_/