### PR TITLE
Retry gubernator before failing

### DIFF
--- a/tests/e2e-gubernator.sh
+++ b/tests/e2e-gubernator.sh
@@ -6,6 +6,8 @@ set -o nounset  # Exit when undeclaried variables are used.
 set -o pipefail  # The exit status of the last command is returned.
 set -o xtrace  # Print the commands that are executed.
 
+source "utils/retry.sh"
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"gce"}
 # The directory to use for this script, should be WORKSPACE, but can be PWD.
@@ -32,7 +34,9 @@ ${SCRIPT_DIRECTORY}/tests/deploy-test-bundle.sh ${MODEL} ${BUNDLE}
 ${SCRIPT_DIRECTORY}/tests/wait-cluster-ready.sh
 
 # Run the end to end tests and copy results to the output directory.
-${SCRIPT_DIRECTORY}/tests/run-e2e-tests.sh ${OUTPUT_DIRECTORY}
+# Retry 3 times. The second and third retries should be quick since
+# we have any images cached
+retry ${SCRIPT_DIRECTORY}/tests/run-e2e-tests.sh ${OUTPUT_DIRECTORY}
 
 # Formats the output data and upload to GCE.
 ${SCRIPT_DIRECTORY}/tests/upload-e2e-results-to-gubernator.sh ${OUTPUT_DIRECTORY}

--- a/tests/run-e2e-tests.sh
+++ b/tests/run-e2e-tests.sh
@@ -20,14 +20,20 @@ juju show-action-output --wait=2h ${ACTION_ID}
 # Print out the action result.
 outcome=`juju show-action-output ${ACTION_ID}`
 echo $outcome
-if [[ "$outcome" == *"failed"* ]]
-then
-  exit 1
-fi
 
 # Download results from the charm and move them to the the volume directory.
 juju scp kubernetes-e2e/0:${ACTION_ID}.log.tar.gz e2e.log.tar.gz
 juju scp kubernetes-e2e/0:${ACTION_ID}-junit.tar.gz e2e-junit.tar.gz
+
+if [[ "$outcome" == *"failed"* ]]
+then
+  echo "${0} failed at `date`."
+  mkdir -p ${OUTPUT_DIRECTORY}/failed
+  tar -xvzf e2e.log.tar.gz -C ${OUTPUT_DIRECTORY}/failed
+  tail -n 30 ${OUTPUT_DIRECTORY}/failed/${ACTION_ID}.log
+  rm -rf ${OUTPUT_DIRECTORY}/failed
+  exit 1
+fi
 
 # Extract the results into the output directory.
 tar -xvzf e2e-junit.tar.gz -C ${OUTPUT_DIRECTORY}


### PR DESCRIPTION
We see the aws tests failing some times. The e2e tests on gce are stable to green so I think this should be some flakiness. Adding a retry although I wish we were able to fix the flakiness in some other way. 