### PR TITLE
Create lxc juju clients to perform parallel execution

### DIFF
--- a/integration-tests/install-deps.sh
+++ b/integration-tests/install-deps.sh
@@ -4,8 +4,16 @@ set -eux
 # Installs dependencies needed for upgrade tests
 # Can be run again to upgrade dependencies.
 
-sudo apt update
-sudo apt install -y python3-pip python-pip
-sudo pip3 install -U pytest pytest-asyncio asyncio_extras juju requests pyyaml kubernetes
-sudo pip2 install -U bundletester
+sudo apt update -yq
+sudo apt install -y unzip python3-pip python-pip squashfuse snapd
+sudo snap install juju --classic
 sudo snap install conjure-up --classic
+sudo snap install charm
+sudo pip2 install 'git+https://github.com/juju/juju-crashdump'
+sudo pip2 install -U pyopenssl bundletester
+sudo pip3 install -U pytest  pytest-asyncio asyncio_extras juju requests pyyaml kubernetes amulet juju
+# Leaving those here in case we need to build a client from bleeding edge
+# sudo pip2 install 'git+https://github.com/juju-solutions/bundletester' \
+#                 'git+https://github.com/juju/juju-crashdump'
+# sudo pip3 install 'git+https://github.com/juju/python-libjuju'
+#                  'git+https://github.com/juju/amulet'

--- a/integration-tests/install-deps.sh
+++ b/integration-tests/install-deps.sh
@@ -5,13 +5,12 @@ set -eux
 # Can be run again to upgrade dependencies.
 
 sudo apt update -yq
-sudo apt install -y unzip python3-pip python-pip squashfuse snapd
+sudo apt install -y unzip python3-pip python-pip squashfuse snapd charm-tools
 sudo snap install juju --classic
 sudo snap install conjure-up --classic
-sudo snap install charm
 sudo pip2 install 'git+https://github.com/juju/juju-crashdump'
 sudo pip2 install -U pyopenssl bundletester
-sudo pip3 install -U pytest  pytest-asyncio asyncio_extras juju requests pyyaml kubernetes amulet juju
+sudo pip3 install -U pytest  pytest-asyncio asyncio_extras juju requests pyyaml kubernetes amulet
 # Leaving those here in case we need to build a client from bleeding edge
 # sudo pip2 install 'git+https://github.com/juju-solutions/bundletester' \
 #                 'git+https://github.com/juju/juju-crashdump'

--- a/integration-tests/test_cdk_parallel.groovy
+++ b/integration-tests/test_cdk_parallel.groovy
@@ -1,0 +1,70 @@
+
+def tests = []
+def clouds = []
+def bundles = []
+def run_bt = false
+
+stage('Input Validation') {
+    echo "CLOUD_AWS: "+CLOUD_AWS
+    echo "CLOUD_GCE: "+CLOUD_GCE
+    echo "CLOUD_LXD: "+CLOUD_LXD
+    echo "TEST_CHARM_CHANNEL: "+TEST_CHARM_CHANNEL
+    echo "TEST_SNAP_CHANNEL: "+TEST_SNAP_CHANNEL
+    echo "TEST_BUNDLES: "+TEST_BUNDLES
+    echo "TESTS_NAMES: "+TESTS_NAMES
+
+    // Fill bundles array
+    bundles = TEST_BUNDLES.replace(' ','').split(',')
+
+    // Fill tests array
+    tests = TESTS_NAMES.replace(' ','').split(',')
+
+    // Fill the clouds array
+    if (CLOUD_AWS == "true") { clouds+="jenkins-ci-aws" }
+    if (CLOUD_GCE == "true") { clouds+="jenkins-ci-gce" }
+    if (CLOUD_LXD == "true") { clouds+="jenkins-ci-lxd" }
+
+    if (tests.contains("test_bundletester")) {
+        echo "Bundletester tests reuqested"
+        run_bt = true
+    }
+}
+stage('Testing') {
+    def jobs = [:]
+
+    for (int t = 0; t < tests.size(); t++) {
+        def test = tests[t]
+        if (test == "test_bundletester") continue
+        for (int c = 0; c < clouds.size(); c++) {
+            def cloud = clouds[c]
+            for (int b = 0; b < bundles.size(); b++) {
+                def bundle = bundles[b]
+                def job_name = (cloud+bundle+test).replace('_','').replace('-','')
+                echo "Preparing job for "+test+" on "+bundle+" on "+cloud
+                jobs[job_name] = {
+                    stage(cloud+" "+bundle+" "+test) {
+                        echo "Running "+job_name
+                        build job: 'test-cdk', parameters: [string(name: 'TEST_CONTROLLER', value: cloud), string(name: 'TEST_CHARM_CHANNEL', value: TEST_CHARM_CHANNEL), string(name: 'TEST_SNAP_CHANNEL', value: TEST_SNAP_CHANNEL), string(name: 'TEST_BUNDLES', value: bundle), [$class: 'NodeParameterValue', name: 'NODE', labels: ['juju-client'], nodeEligibility: [$class: 'AllNodeEligibility']], string(name: 'TEST_NAME', value: test)]
+                    } 
+                }
+            }
+        }
+    }
+
+    if (run_bt){
+        def test = "test_bundletester"
+        for (int c = 0; c < clouds.size(); c++) {
+            def cloud = clouds[c]
+            def job_name = (cloud+test).replace('_','').replace('-','')
+            echo "Preparing job for "+test+" on "+cloud
+            jobs[job_name] = {
+                stage(cloud+" "+test) {
+                    echo "Running "+job_name
+                    build job: 'test-cdk', parameters: [string(name: 'TEST_CONTROLLER', value: cloud), string(name: 'TEST_CHARM_CHANNEL', value: TEST_CHARM_CHANNEL), string(name: 'TEST_SNAP_CHANNEL', value: TEST_SNAP_CHANNEL), string(name: 'TEST_BUNDLES', value: "kubernetes-core"), [$class: 'NodeParameterValue', name: 'NODE', labels: ['juju-client'], nodeEligibility: [$class: 'AllNodeEligibility']], string(name: 'TEST_NAME', value: test)]
+                }
+            }
+        }
+    }
+
+    parallel jobs
+}

--- a/integration-tests/test_cdk_parallel.groovy
+++ b/integration-tests/test_cdk_parallel.groovy
@@ -21,7 +21,7 @@ stage('Input Validation') {
 
     // Fill the clouds array
     if (CLOUD_AWS == "true") { clouds+="jenkins-ci-aws" }
-    if (CLOUD_GCE == "true") { clouds+="jenkins-ci-gce" }
+    if (CLOUD_GCE == "true") { clouds+="jenkins-ci-google" }
     if (CLOUD_LXD == "true") { clouds+="jenkins-ci-lxd" }
 
     if (tests.contains("test_bundletester")) {

--- a/maintenance/copy-juju-to-lxc-node.sh
+++ b/maintenance/copy-juju-to-lxc-node.sh
@@ -7,8 +7,11 @@ container=${NODE_NAME:-"juju-client-box"}
 container_exists $container
 
 RUN rm -rf /root/.local/share/juju/*
+RUN rm -rf /var/lib/jenkins/.local/share/juju/*
 PUSH ~/.local/share/juju/accounts.yaml /root/.local/share/juju/
 PUSH ~/.local/share/juju/models.yaml /root/.local/share/juju/
 PUSH ~/.local/share/juju/controllers.yaml /root/.local/share/juju/
 PUSH ~/.local/share/juju/credentials.yaml /root/.local/share/juju/
+RUN mkdir -p /var/lib/jenkins/.local/share/juju
+PUSH ~/.local/share/juju/foo.json /var/lib/jenkins/.local/share/juju/
 

--- a/maintenance/copy-juju-to-lxc-node.sh
+++ b/maintenance/copy-juju-to-lxc-node.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+source ./maintenance/helpers-lxc-node.sh
+
+container=${NODE_NAME:-"juju-client-box"}
+container_exists $container
+
+RUN rm -rf /root/.local/share/juju/*
+PUSH ~/.local/share/juju/accounts.yaml /root/.local/share/juju/
+PUSH ~/.local/share/juju/models.yaml /root/.local/share/juju/
+PUSH ~/.local/share/juju/controllers.yaml /root/.local/share/juju/
+PUSH ~/.local/share/juju/credentials.yaml /root/.local/share/juju/
+

--- a/maintenance/decomission-lxc-node.sh
+++ b/maintenance/decomission-lxc-node.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+source ./maintenance/helpers-lxc-node.sh
+
+container=${NODE_NAME:-"juju-client-box"}
+container_exists $container
+
+lxc stop $container
+lxc delete --force $container

--- a/maintenance/helpers-lxc-node.sh
+++ b/maintenance/helpers-lxc-node.sh
@@ -1,0 +1,20 @@
+function RUN() {
+    lxc exec $container -- "$@"
+}
+
+function PUSH() {
+    src="$1"
+    dst="$(echo $2 | sed -e 's/^\///')"
+    shift 2
+    lxc file push "$src" $container/"$dst" "$@"
+}
+
+
+function container_exists() {
+  if ! lxc list  | grep $container
+  then
+    echo "Container $container not found. Please select a container from the list below."
+    lxc list
+    exit 1
+  fi
+}

--- a/maintenance/provision-lxc-node.sh
+++ b/maintenance/provision-lxc-node.sh
@@ -11,22 +11,9 @@ while ! lxc info $container | grep -qE 'eth0:\sinet\s'; do
     sleep 3
 done
 
-RUN add-apt-repository -y ppa:juju/stable
-RUN apt update -yq
-RUN apt install -y juju unzip python3-pip python-pip charm-tools squashfuse snapd
-RUN pip2 install 'git+https://github.com/juju-solutions/bundletester' \
-                 'git+https://github.com/juju-solutions/cloud-weather-report' \
-                 'git+https://github.com/juju/juju-crashdump'
-RUN pip3 install 'git+https://github.com/juju/python-libjuju' \
-                 'git+https://github.com/juju-solutions/matrix' \
-                 'git+https://github.com/juju/amulet'
+PUSH integration-tests/install-deps.sh /root/
+RUN /root/install-deps.sh
 
-
-RUN pip2 install -U charm-tools pyopenssl
-RUN pip3 install -U pytest  pytest-asyncio asyncio_extras juju requests pyyaml kubernetes
-RUN snap install conjure-up --classic
-
-RUN mkdir -p /srv/artifacts
 RUN mkdir -p /root/.local/share/juju
 
 PUSH ~/.local/share/juju/accounts.yaml /root/.local/share/juju/

--- a/maintenance/provision-lxc-node.sh
+++ b/maintenance/provision-lxc-node.sh
@@ -33,6 +33,8 @@ PUSH ~/.local/share/juju/accounts.yaml /root/.local/share/juju/
 PUSH ~/.local/share/juju/models.yaml /root/.local/share/juju/
 PUSH ~/.local/share/juju/controllers.yaml /root/.local/share/juju/
 PUSH ~/.local/share/juju/credentials.yaml /root/.local/share/juju/ 
+RUN mkdir -p /var/lib/jenkins/.local/share/juju
+PUSH ~/.local/share/juju/foo.json /var/lib/jenkins/.local/share/juju/
 
 # Allow ssh access
 RUN mkdir -p /root/.ssh

--- a/maintenance/provision-lxc-node.sh
+++ b/maintenance/provision-lxc-node.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -ex
+source ./maintenance/helpers-lxc-node.sh
+
+container=${NODE_NAME:-"juju-client-box"}
+
+lxc launch ubuntu:16.04 $container
+
+while ! lxc info $container | grep -qE 'eth0:\sinet\s'; do
+    sleep 3
+done
+
+RUN add-apt-repository -y ppa:juju/stable
+RUN apt update -yq
+RUN apt install -y juju unzip python3-pip python-pip charm-tools squashfuse snapd
+RUN pip2 install 'git+https://github.com/juju-solutions/bundletester' \
+                 'git+https://github.com/juju-solutions/cloud-weather-report' \
+                 'git+https://github.com/juju/juju-crashdump'
+RUN pip3 install 'git+https://github.com/juju/python-libjuju' \
+                 'git+https://github.com/juju-solutions/matrix' \
+                 'git+https://github.com/juju/amulet'
+
+
+RUN pip2 install -U charm-tools pyopenssl
+RUN pip3 install -U pytest  pytest-asyncio asyncio_extras juju requests pyyaml kubernetes
+RUN snap install conjure-up --classic
+
+RUN mkdir -p /srv/artifacts
+RUN mkdir -p /root/.local/share/juju
+
+PUSH ~/.local/share/juju/accounts.yaml /root/.local/share/juju/
+PUSH ~/.local/share/juju/models.yaml /root/.local/share/juju/
+PUSH ~/.local/share/juju/controllers.yaml /root/.local/share/juju/
+PUSH ~/.local/share/juju/credentials.yaml /root/.local/share/juju/ 
+
+# Allow ssh access
+RUN mkdir -p /root/.ssh
+PUSH ~/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN chmod 600 /root/.ssh/authorized_keys
+RUN chown root:root /root/.ssh/authorized_keys
+
+# Jenkins agent needs java
+RUN apt-get install -y default-jre
+
+RUN mkdir -p /root/bin
+RUN wget https://ci.kubernetes.juju.solutions/jnlpJars/slave.jar
+RUN mv slave.jar /root/bin
+
+echo "Your lxc container is ready to be added as jenkins node."
+echo "Go to Manage Jenkins -> Manage Nodes -> New Node and select"
+echo "Launch agent via execution of command on the master and enter the following:"
+echo "ssh -o StrictHostKeyChecking=no -v root@<container_ip> java -jar ~/bin/slave.jar"
+lxc list

--- a/tests/test_cdk_parallel.groovy
+++ b/tests/test_cdk_parallel.groovy
@@ -37,6 +37,11 @@ stage('Testing') {
         if (test == "test_bundletester") continue
         for (int c = 0; c < clouds.size(); c++) {
             def cloud = clouds[c]
+            def node = "juju-client"
+            if (cloud == "jenkins-ci-lxd") {
+                // lxd runs on its own machine
+                node = "lxdnode"
+            }
             for (int b = 0; b < bundles.size(); b++) {
                 def bundle = bundles[b]
                 def job_name = (cloud+bundle+test).replace('_','').replace('-','')
@@ -44,7 +49,7 @@ stage('Testing') {
                 jobs[job_name] = {
                     stage(cloud+" "+bundle+" "+test) {
                         echo "Running "+job_name
-                        build job: 'test-cdk', parameters: [string(name: 'TEST_CONTROLLER', value: cloud), string(name: 'TEST_CHARM_CHANNEL', value: TEST_CHARM_CHANNEL), string(name: 'TEST_SNAP_CHANNEL', value: TEST_SNAP_CHANNEL), string(name: 'TEST_BUNDLES', value: bundle), [$class: 'NodeParameterValue', name: 'NODE', labels: ['juju-client'], nodeEligibility: [$class: 'AllNodeEligibility']], string(name: 'TEST_NAME', value: test)]
+                        build job: 'test-cdk', parameters: [string(name: 'TEST_CONTROLLER', value: cloud), string(name: 'TEST_CHARM_CHANNEL', value: TEST_CHARM_CHANNEL), string(name: 'TEST_SNAP_CHANNEL', value: TEST_SNAP_CHANNEL), string(name: 'TEST_BUNDLES', value: bundle), [$class: 'NodeParameterValue', name: 'NODE', labels: [node], nodeEligibility: [$class: 'AllNodeEligibility']], string(name: 'TEST_NAME', value: test)]
                     } 
                 }
             }
@@ -55,12 +60,17 @@ stage('Testing') {
         def test = "test_bundletester"
         for (int c = 0; c < clouds.size(); c++) {
             def cloud = clouds[c]
+            def node = "juju-client"
+            if (cloud == "jenkins-ci-lxd") {
+                // lxd runs on its own machine
+                node = "lxdnode"
+            }
             def job_name = (cloud+test).replace('_','').replace('-','')
             echo "Preparing job for "+test+" on "+cloud
             jobs[job_name] = {
                 stage(cloud+" "+test) {
                     echo "Running "+job_name
-                    build job: 'test-cdk', parameters: [string(name: 'TEST_CONTROLLER', value: cloud), string(name: 'TEST_CHARM_CHANNEL', value: TEST_CHARM_CHANNEL), string(name: 'TEST_SNAP_CHANNEL', value: TEST_SNAP_CHANNEL), string(name: 'TEST_BUNDLES', value: "kubernetes-core"), [$class: 'NodeParameterValue', name: 'NODE', labels: ['juju-client'], nodeEligibility: [$class: 'AllNodeEligibility']], string(name: 'TEST_NAME', value: test)]
+                    build job: 'test-cdk', parameters: [string(name: 'TEST_CONTROLLER', value: cloud), string(name: 'TEST_CHARM_CHANNEL', value: TEST_CHARM_CHANNEL), string(name: 'TEST_SNAP_CHANNEL', value: TEST_SNAP_CHANNEL), string(name: 'TEST_BUNDLES', value: "kubernetes-core"), [$class: 'NodeParameterValue', name: 'NODE', labels: [node], nodeEligibility: [$class: 'AllNodeEligibility']], string(name: 'TEST_NAME', value: test)]
                 }
             }
         }


### PR DESCRIPTION
We have a few scripts to create, decommission lxc juju clients as well as copying juju credentials to those clients in case we change them on the master. Have a look at the jobs in this Jenkins view: https://ci.kubernetes.juju.solutions/view/Maintenance/

In this PR there is also a script that would create a job invocation per cloud, bundle, test combination. This script is used in this jenkins job: https://ci.kubernetes.juju.solutions/view/Charms%20and%20Bundles/job/test-cdk-parallel/