### PR TITLE
Fix exception when calling logger.log in asyncify'd function

### DIFF
--- a/integration-tests/logger.py
+++ b/integration-tests/logger.py
@@ -1,13 +1,10 @@
-import asyncio
 import traceback
 from datetime import datetime
 
 
 def log(msg):
     timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    task = asyncio.Task.current_task()
-    task_id = id(task)
-    print('[%s|%s] %s' % (timestamp, task_id, msg))
+    print('[%s] %s' % (timestamp, msg))
 
 
 def function_call_str(f, args, kwargs):


### PR DESCRIPTION
This fixes the rather ugly error pasted below. I found this while testing on LXD, where the `asyncify(apply_profile)` happens to hit this case.

This error occurs because my `log` function assumes it is running in an async context, but `asyncify` escapes out of the async context and runs code in an OS thread instead. Oops.

The fix is to not include async task IDs in the log message - doesn't seem worth it anymore.

UGLY STACKTRACE GO
```
test_docker_proposed.py:37: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/local/lib/python3.5/dist-packages/async_generator/impl.py:261: in asend
    return await self._do_it(self._it.send, value)
/usr/local/lib/python3.5/dist-packages/async_generator/impl.py:277: in _do_it
    return await ANextIter(self._it, start_fn, *args)
/usr/local/lib/python3.5/dist-packages/async_generator/impl.py:195: in throw
    return self._invoke(self._it.throw, type, value, traceback)
/usr/local/lib/python3.5/dist-packages/async_generator/impl.py:199: in _invoke
    result = fn(*args)
utils.py:160: in temporary_model
    await controller.disconnect()
/usr/lib/python3.5/contextlib.py:77: in __exit__
    self.gen.throw(type, value, traceback)
utils.py:103: in timeout_for_current_task
    yield
utils.py:153: in temporary_model
    await asyncify(apply_profile)(model_name)
utils.py:265: in wrapper
    return await loop.run_in_executor(None, partial)
/usr/lib/python3.5/asyncio/futures.py:361: in __iter__
    yield self  # This tells Task to wait for completion.
/usr/lib/python3.5/asyncio/tasks.py:296: in _wakeup
    future.result()
/usr/lib/python3.5/asyncio/futures.py:274: in result
    raise self._exception
/usr/lib/python3.5/concurrent/futures/thread.py:55: in run
    result = self.fn(*self.args, **self.kwargs)
logger.py:33: in wrapper
    log('START ' + f_str)
logger.py:8: in log
    task = asyncio.Task.current_task()
/usr/lib/python3.5/asyncio/tasks.py:56: in current_task
    loop = events.get_event_loop()
/usr/lib/python3.5/asyncio/events.py:632: in get_event_loop
    return get_event_loop_policy().get_event_loop()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <asyncio.unix_events._UnixDefaultEventLoopPolicy object at 0x7ffbc97a0668>

    def get_event_loop(self):
        """Get the event loop.
    
            This may be None or an instance of EventLoop.
            """
        if (self._local._loop is None and
            not self._local._set_called and
            isinstance(threading.current_thread(), threading._MainThread)):
            self.set_event_loop(self.new_event_loop())
        if self._local._loop is None:
            raise RuntimeError('There is no current event loop in thread %r.'
>                              % threading.current_thread().name)
E           RuntimeError: There is no current event loop in thread 'Thread-2'.
```