### PR TITLE
Install amulet from git/master

### DIFF
--- a/integration-tests/install-deps.sh
+++ b/integration-tests/install-deps.sh
@@ -10,9 +10,10 @@ sudo snap install juju --classic
 sudo snap install conjure-up --classic
 sudo pip2 install 'git+https://github.com/juju/juju-crashdump'
 sudo pip2 install -U pyopenssl bundletester
-sudo pip3 install -U pytest  pytest-asyncio asyncio_extras juju requests pyyaml kubernetes amulet
+sudo pip3 install -U pytest  pytest-asyncio asyncio_extras juju requests pyyaml kubernetes
+sudo pip3 install -U 'git+https://github.com/juju/amulet' # we need https://github.com/juju/amulet/pull/183
+
 # Leaving those here in case we need to build a client from bleeding edge
 # sudo pip2 install 'git+https://github.com/juju-solutions/bundletester' \
 #                 'git+https://github.com/juju/juju-crashdump'
 # sudo pip3 install 'git+https://github.com/juju/python-libjuju'
-#                  'git+https://github.com/juju/amulet'


### PR DESCRIPTION
Fix for this failure seen in test-cdk #217

```
Traceback (most recent call last):
  File "/tmp/bundletester-0wef3M/canonical-kubernetes/tests/20-charm-validation.py", line 196, in test_etcd_scale_on_master
    self.deployment.sentry.wait(timeout=900)
  File "/usr/local/lib/python3.5/dist-packages/amulet/sentry.py", line 563, in wait
    if check_status(status):
  File "/usr/local/lib/python3.5/dist-packages/amulet/sentry.py", line 547, in check_status
    if unit['agent-status']['current'] != 'idle':
KeyError: 'current'
```

I fixed this in amulet months ago, but it never got released to pypi. See https://github.com/juju/amulet/pull/183