### PR TITLE
don't use missing model.info.uuid

### DIFF
--- a/integration-tests/utils.py
+++ b/integration-tests/utils.py
@@ -156,7 +156,7 @@ async def temporary_model(log_dir, timeout=7200, force_cloud=''):
                 await yield_(model)
         finally:
             await model.disconnect()
-            await controller.destroy_model(model.info.uuid)
+            await controller.destroy_model(model_name)
             await controller.disconnect()
 
 


### PR DESCRIPTION
Fixes this error:

```
    async def temporary_model(log_dir, timeout=7200, force_cloud=''):
        ''' Create and destroy a temporary Juju model named cdk-build-upgrade-*.
    
        This is an async context, to be used within an `async with` statement.
        '''
        with timeout_for_current_task(timeout):
            controller = Controller()
            await controller.connect_current()
            model_name = 'cdk-build-upgrade-%d' % random.randint(0, 10000)
            model_config = {'test-mode': True}
            model = await add_model_via_cli(controller, model_name, model_config, force_cloud)
            cloud = await controller.get_cloud()
            if cloud == 'localhost':
                await asyncify(apply_profile)(model_name)
            try:
                async with captured_fail_logs(model, log_dir):
                    await yield_(model)
            finally:
                await model.disconnect()
>               await controller.destroy_model(model.info.uuid)
E               AttributeError: 'NoneType' object has no attribute 'uuid'
```