### PR TITLE
Flush stdout when writing log messages

### DIFF
--- a/integration-tests/logger.py
+++ b/integration-tests/logger.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 def log(msg):
     timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    print('[%s] %s' % (timestamp, msg))
+    print('[%s] %s' % (timestamp, msg), flush=True)
 
 
 def function_call_str(f, args, kwargs):


### PR DESCRIPTION
test-cdk #277 mysteriously ran for >3 hours before I had to abort it. The console output is completely useless because the last thing it shows is well before whatever failure occurred. Hoping to fix that here...