### PR TITLE
validate_docker_logins: Use emptyDir volume to persist data

### DIFF
--- a/integration-tests/pytestdebug.log
+++ b/integration-tests/pytestdebug.log
@@ -1,0 +1,906 @@
+versions pytest-3.2.1, py-1.4.34, python-3.5.2.final.0
+cwd=/home/jackal/workspace/charms/kubernetes-jenkins/integration-tests
+args=['-v', './test_live_model.py', '--debug', '-s']
+
+  pytest_cmdline_main [hook]
+      config: <_pytest.config.Config object at 0x7fd170f87588>
+    pytest_plugin_registered [hook]
+        manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+        plugin: <Session 'integration-tests'>
+    finish pytest_plugin_registered --> [] [hook]
+    pytest_configure [hook]
+        config: <_pytest.config.Config object at 0x7fd170f87588>
+      pytest_plugin_registered [hook]
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.cacheprovider.LFPlugin object at 0x7fd16f1f91d0>
+      finish pytest_plugin_registered --> [] [hook]
+    find_module called for: py._io [assertion]
+    find_module called for: py._io.terminalwriter [assertion]
+    find_module called for: termios [assertion]
+    find_module called for: fcntl [assertion]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <_pytest.config.PytestPluginManager object at 0x7fd171428400>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <_pytest.config.Config object at 0x7fd170f87588>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.config.Config object at 0x7fd170f87588>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.mark' from '/usr/local/lib/python3.5/dist-packages/_pytest/mark.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.mark' from '/usr/local/lib/python3.5/dist-packages/_pytest/mark.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.main' from '/usr/local/lib/python3.5/dist-packages/_pytest/main.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.main' from '/usr/local/lib/python3.5/dist-packages/_pytest/main.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.terminal' from '/usr/local/lib/python3.5/dist-packages/_pytest/terminal.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.terminal' from '/usr/local/lib/python3.5/dist-packages/_pytest/terminal.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.runner' from '/usr/local/lib/python3.5/dist-packages/_pytest/runner.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.runner' from '/usr/local/lib/python3.5/dist-packages/_pytest/runner.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.python' from '/usr/local/lib/python3.5/dist-packages/_pytest/python.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.python' from '/usr/local/lib/python3.5/dist-packages/_pytest/python.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.fixtures' from '/usr/local/lib/python3.5/dist-packages/_pytest/fixtures.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.fixtures' from '/usr/local/lib/python3.5/dist-packages/_pytest/fixtures.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.debugging' from '/usr/local/lib/python3.5/dist-packages/_pytest/debugging.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.debugging' from '/usr/local/lib/python3.5/dist-packages/_pytest/debugging.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.unittest' from '/usr/local/lib/python3.5/dist-packages/_pytest/unittest.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.unittest' from '/usr/local/lib/python3.5/dist-packages/_pytest/unittest.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.capture' from '/usr/local/lib/python3.5/dist-packages/_pytest/capture.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.capture' from '/usr/local/lib/python3.5/dist-packages/_pytest/capture.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.skipping' from '/usr/local/lib/python3.5/dist-packages/_pytest/skipping.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.skipping' from '/usr/local/lib/python3.5/dist-packages/_pytest/skipping.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.tmpdir' from '/usr/local/lib/python3.5/dist-packages/_pytest/tmpdir.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.tmpdir' from '/usr/local/lib/python3.5/dist-packages/_pytest/tmpdir.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.monkeypatch' from '/usr/local/lib/python3.5/dist-packages/_pytest/monkeypatch.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.monkeypatch' from '/usr/local/lib/python3.5/dist-packages/_pytest/monkeypatch.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.recwarn' from '/usr/local/lib/python3.5/dist-packages/_pytest/recwarn.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.recwarn' from '/usr/local/lib/python3.5/dist-packages/_pytest/recwarn.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.pastebin' from '/usr/local/lib/python3.5/dist-packages/_pytest/pastebin.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.pastebin' from '/usr/local/lib/python3.5/dist-packages/_pytest/pastebin.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.helpconfig' from '/usr/local/lib/python3.5/dist-packages/_pytest/helpconfig.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.helpconfig' from '/usr/local/lib/python3.5/dist-packages/_pytest/helpconfig.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.nose' from '/usr/local/lib/python3.5/dist-packages/_pytest/nose.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.nose' from '/usr/local/lib/python3.5/dist-packages/_pytest/nose.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.assertion' from '/usr/local/lib/python3.5/dist-packages/_pytest/assertion/__init__.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.assertion' from '/usr/local/lib/python3.5/dist-packages/_pytest/assertion/__init__.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.junitxml' from '/usr/local/lib/python3.5/dist-packages/_pytest/junitxml.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.junitxml' from '/usr/local/lib/python3.5/dist-packages/_pytest/junitxml.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.resultlog' from '/usr/local/lib/python3.5/dist-packages/_pytest/resultlog.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.resultlog' from '/usr/local/lib/python3.5/dist-packages/_pytest/resultlog.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.doctest' from '/usr/local/lib/python3.5/dist-packages/_pytest/doctest.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.doctest' from '/usr/local/lib/python3.5/dist-packages/_pytest/doctest.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.cacheprovider' from '/usr/local/lib/python3.5/dist-packages/_pytest/cacheprovider.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.cacheprovider' from '/usr/local/lib/python3.5/dist-packages/_pytest/cacheprovider.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.freeze_support' from '/usr/local/lib/python3.5/dist-packages/_pytest/freeze_support.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.freeze_support' from '/usr/local/lib/python3.5/dist-packages/_pytest/freeze_support.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.setuponly' from '/usr/local/lib/python3.5/dist-packages/_pytest/setuponly.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.setuponly' from '/usr/local/lib/python3.5/dist-packages/_pytest/setuponly.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.setupplan' from '/usr/local/lib/python3.5/dist-packages/_pytest/setupplan.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.setupplan' from '/usr/local/lib/python3.5/dist-packages/_pytest/setupplan.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.warnings' from '/usr/local/lib/python3.5/dist-packages/_pytest/warnings.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.warnings' from '/usr/local/lib/python3.5/dist-packages/_pytest/warnings.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module 'pytest_asyncio.plugin' (<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>)>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module 'pytest_asyncio.plugin' (<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>)>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <_pytest.capture.CaptureManager object at 0x7fd16f6e8978>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.capture.CaptureManager object at 0x7fd16f6e8978>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module 'conftest' (<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>)>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module 'conftest' (<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>)>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <Session 'integration-tests'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <Session 'integration-tests'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <_pytest.cacheprovider.LFPlugin object at 0x7fd16f1f91d0>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.cacheprovider.LFPlugin object at 0x7fd16f1f91d0>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.terminal.TerminalReporter object at 0x7fd16f1f9438>
+      finish pytest_plugin_registered --> [] [hook]
+    finish pytest_configure --> [] [hook]
+    pytest_sessionstart [hook]
+        session: <Session 'integration-tests'>
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <_pytest.config.PytestPluginManager object at 0x7fd171428400>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <_pytest.config.Config object at 0x7fd170f87588>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.config.Config object at 0x7fd170f87588>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.mark' from '/usr/local/lib/python3.5/dist-packages/_pytest/mark.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.mark' from '/usr/local/lib/python3.5/dist-packages/_pytest/mark.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.main' from '/usr/local/lib/python3.5/dist-packages/_pytest/main.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.main' from '/usr/local/lib/python3.5/dist-packages/_pytest/main.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.terminal' from '/usr/local/lib/python3.5/dist-packages/_pytest/terminal.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.terminal' from '/usr/local/lib/python3.5/dist-packages/_pytest/terminal.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.runner' from '/usr/local/lib/python3.5/dist-packages/_pytest/runner.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.runner' from '/usr/local/lib/python3.5/dist-packages/_pytest/runner.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.python' from '/usr/local/lib/python3.5/dist-packages/_pytest/python.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.python' from '/usr/local/lib/python3.5/dist-packages/_pytest/python.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.fixtures' from '/usr/local/lib/python3.5/dist-packages/_pytest/fixtures.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.fixtures' from '/usr/local/lib/python3.5/dist-packages/_pytest/fixtures.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.debugging' from '/usr/local/lib/python3.5/dist-packages/_pytest/debugging.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.debugging' from '/usr/local/lib/python3.5/dist-packages/_pytest/debugging.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.unittest' from '/usr/local/lib/python3.5/dist-packages/_pytest/unittest.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.unittest' from '/usr/local/lib/python3.5/dist-packages/_pytest/unittest.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.capture' from '/usr/local/lib/python3.5/dist-packages/_pytest/capture.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.capture' from '/usr/local/lib/python3.5/dist-packages/_pytest/capture.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.skipping' from '/usr/local/lib/python3.5/dist-packages/_pytest/skipping.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.skipping' from '/usr/local/lib/python3.5/dist-packages/_pytest/skipping.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.tmpdir' from '/usr/local/lib/python3.5/dist-packages/_pytest/tmpdir.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.tmpdir' from '/usr/local/lib/python3.5/dist-packages/_pytest/tmpdir.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.monkeypatch' from '/usr/local/lib/python3.5/dist-packages/_pytest/monkeypatch.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.monkeypatch' from '/usr/local/lib/python3.5/dist-packages/_pytest/monkeypatch.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.recwarn' from '/usr/local/lib/python3.5/dist-packages/_pytest/recwarn.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.recwarn' from '/usr/local/lib/python3.5/dist-packages/_pytest/recwarn.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.pastebin' from '/usr/local/lib/python3.5/dist-packages/_pytest/pastebin.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.pastebin' from '/usr/local/lib/python3.5/dist-packages/_pytest/pastebin.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.helpconfig' from '/usr/local/lib/python3.5/dist-packages/_pytest/helpconfig.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.helpconfig' from '/usr/local/lib/python3.5/dist-packages/_pytest/helpconfig.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.nose' from '/usr/local/lib/python3.5/dist-packages/_pytest/nose.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.nose' from '/usr/local/lib/python3.5/dist-packages/_pytest/nose.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.assertion' from '/usr/local/lib/python3.5/dist-packages/_pytest/assertion/__init__.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.assertion' from '/usr/local/lib/python3.5/dist-packages/_pytest/assertion/__init__.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.junitxml' from '/usr/local/lib/python3.5/dist-packages/_pytest/junitxml.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.junitxml' from '/usr/local/lib/python3.5/dist-packages/_pytest/junitxml.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.resultlog' from '/usr/local/lib/python3.5/dist-packages/_pytest/resultlog.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.resultlog' from '/usr/local/lib/python3.5/dist-packages/_pytest/resultlog.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.doctest' from '/usr/local/lib/python3.5/dist-packages/_pytest/doctest.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.doctest' from '/usr/local/lib/python3.5/dist-packages/_pytest/doctest.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.cacheprovider' from '/usr/local/lib/python3.5/dist-packages/_pytest/cacheprovider.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.cacheprovider' from '/usr/local/lib/python3.5/dist-packages/_pytest/cacheprovider.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.freeze_support' from '/usr/local/lib/python3.5/dist-packages/_pytest/freeze_support.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.freeze_support' from '/usr/local/lib/python3.5/dist-packages/_pytest/freeze_support.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.setuponly' from '/usr/local/lib/python3.5/dist-packages/_pytest/setuponly.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.setuponly' from '/usr/local/lib/python3.5/dist-packages/_pytest/setuponly.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.setupplan' from '/usr/local/lib/python3.5/dist-packages/_pytest/setupplan.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.setupplan' from '/usr/local/lib/python3.5/dist-packages/_pytest/setupplan.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module '_pytest.warnings' from '/usr/local/lib/python3.5/dist-packages/_pytest/warnings.py'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module '_pytest.warnings' from '/usr/local/lib/python3.5/dist-packages/_pytest/warnings.py'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module 'pytest_asyncio.plugin' (<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>)>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module 'pytest_asyncio.plugin' (<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>)>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <_pytest.capture.CaptureManager object at 0x7fd16f6e8978>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.capture.CaptureManager object at 0x7fd16f6e8978>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <module 'conftest' (<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>)>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <module 'conftest' (<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>)>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <Session 'integration-tests'>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <Session 'integration-tests'>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <_pytest.cacheprovider.LFPlugin object at 0x7fd16f1f91d0>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.cacheprovider.LFPlugin object at 0x7fd16f1f91d0>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          __multicall__: <_MultiCall 0 results, 0 meths, kwargs={'__multicall__': <_MultiCall 0 results, 0 meths, kwargs={...}>, 'manager': <_pytest.config.PytestPluginManager object at 0x7fd171428400>, 'plugin': <_pytest.terminal.TerminalReporter object at 0x7fd16f1f9438>}>
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.terminal.TerminalReporter object at 0x7fd16f1f9438>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_plugin_registered [hook]
+          manager: <_pytest.config.PytestPluginManager object at 0x7fd171428400>
+          plugin: <_pytest.fixtures.FixtureManager object at 0x7fd16f2093c8>
+      finish pytest_plugin_registered --> [] [hook]
+      pytest_report_header [hook]
+          config: <_pytest.config.Config object at 0x7fd170f87588>
+          startdir: /home/jackal/workspace/charms/kubernetes-jenkins/integration-tests
+      finish pytest_report_header --> [['rootdir: /home/jackal/workspace/charms/kubernetes-jenkins/integration-tests, inifile:', 'plugins: asyncio-0.6.0'], 'cachedir: .cache', ['using: pytest-3.2.1 pylib-1.4.34', 'setuptools registered plugins:', '  pytest-asyncio-0.6.0 at /usr/local/lib/python3.5/dist-packages/pytest_asyncio/plugin.py']] [hook]
+    finish pytest_sessionstart --> [] [hook]
+    pytest_collection [hook]
+        session: <Session 'integration-tests'>
+    perform_collect <Session 'integration-tests'> ['./test_live_model.py'] [collection]
+        pytest_collectstart [hook]
+            collector: <Session 'integration-tests'>
+        finish pytest_collectstart --> [] [hook]
+        pytest_make_collect_report [hook]
+            collector: <Session 'integration-tests'>
+        processing argument /home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/test_live_model.py [collection]
+            pytest_collect_file [hook]
+                parent: <Session 'integration-tests'>
+                path: /home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/test_live_model.py
+              pytest_pycollect_makemodule [hook]
+                  parent: <Session 'integration-tests'>
+                  path: /home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/test_live_model.py
+              finish pytest_pycollect_makemodule --> <Module 'test_live_model.py'> [hook]
+            finish pytest_collect_file --> [<Module 'test_live_model.py'>] [hook]
+          matchnodes [<Module 'test_live_model.py'>] [] [collection]
+            matchnodes finished ->  1 nodes [collection]
+        finish pytest_make_collect_report --> <CollectReport '' lenresult=1 outcome='passed'> [hook]
+        pytest_collectreport [hook]
+            report: <CollectReport '' lenresult=1 outcome='passed'>
+        finish pytest_collectreport --> [] [hook]
+    genitems <Module 'test_live_model.py'> [collection]
+      pytest_collectstart [hook]
+          collector: <Module 'test_live_model.py'>
+      finish pytest_collectstart --> [] [hook]
+      pytest_make_collect_report [hook]
+          collector: <Module 'test_live_model.py'>
+      find_module called for: test_live_model [assertion]
+      matched test file (was specified on cmdline): '/home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/test_live_model.py' [assertion]
+      found cached rewritten pyc for '/home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/test_live_model.py' [assertion]
+      find_module called for: juju [assertion]
+      find_module called for: juju.model [assertion]
+      find_module called for: pathlib [assertion]
+      find_module called for: ntpath [assertion]
+      find_module called for: nt [assertion]
+      find_module called for: nt [assertion]
+      find_module called for: nt [assertion]
+      find_module called for: websockets [assertion]
+      find_module called for: websockets.client [assertion]
+      find_module called for: websockets.exceptions [assertion]
+      find_module called for: websockets.handshake [assertion]
+      find_module called for: websockets.http [assertion]
+      find_module called for: http [assertion]
+      find_module called for: http.client [assertion]
+      find_module called for: websockets.version [assertion]
+      find_module called for: websockets.protocol [assertion]
+      find_module called for: websockets.compatibility [assertion]
+      find_module called for: websockets.framing [assertion]
+      find_module called for: websockets.speedups [assertion]
+      find_module called for: websockets.uri [assertion]
+      find_module called for: websockets.py35 [assertion]
+      find_module called for: websockets.py35.client [assertion]
+      find_module called for: websockets.server [assertion]
+      find_module called for: websockets.py35.server [assertion]
+      find_module called for: yaml [assertion]
+      find_module called for: yaml.error [assertion]
+      find_module called for: yaml.tokens [assertion]
+      find_module called for: yaml.events [assertion]
+      find_module called for: yaml.nodes [assertion]
+      find_module called for: yaml.loader [assertion]
+      find_module called for: yaml.reader [assertion]
+      find_module called for: yaml.scanner [assertion]
+      find_module called for: yaml.parser [assertion]
+      find_module called for: yaml.composer [assertion]
+      find_module called for: yaml.constructor [assertion]
+      find_module called for: yaml.resolver [assertion]
+      find_module called for: yaml.dumper [assertion]
+      find_module called for: yaml.emitter [assertion]
+      find_module called for: yaml.serializer [assertion]
+      find_module called for: yaml.representer [assertion]
+      find_module called for: yaml.cyaml [assertion]
+      find_module called for: _yaml [assertion]
+      find_module called for: theblues [assertion]
+      find_module called for: theblues.charmstore [assertion]
+      find_module called for: urllib.urlencode [assertion]
+      find_module called for: requests [assertion]
+      find_module called for: urllib3 [assertion]
+      find_module called for: urllib3.connectionpool [assertion]
+      find_module called for: urllib3.exceptions [assertion]
+      find_module called for: urllib3.packages [assertion]
+      find_module called for: urllib3.packages.ssl_match_hostname [assertion]
+      find_module called for: urllib3.packages.six [assertion]
+      find_module called for: urllib3.packages.six.moves [assertion]
+      find_module called for: urllib3.packages.six.moves.http_client [assertion]
+      find_module called for: urllib3.connection [assertion]
+      find_module called for: urllib3.util [assertion]
+      find_module called for: urllib3.util.connection [assertion]
+      find_module called for: urllib3.util.wait [assertion]
+      find_module called for: urllib3.util.selectors [assertion]
+      find_module called for: urllib3.util.request [assertion]
+      find_module called for: urllib3.util.response [assertion]
+      find_module called for: urllib3.util.ssl_ [assertion]
+      find_module called for: hmac [assertion]
+      find_module called for: urllib3.util.timeout [assertion]
+      find_module called for: urllib3.util.retry [assertion]
+      find_module called for: urllib3.util.url [assertion]
+      find_module called for: urllib3._collections [assertion]
+      find_module called for: urllib3.request [assertion]
+      find_module called for: urllib3.filepost [assertion]
+      find_module called for: uuid [assertion]
+      find_module called for: ctypes [assertion]
+      find_module called for: _ctypes [assertion]
+      find_module called for: ctypes._endian [assertion]
+      find_module called for: ctypes.util [assertion]
+      find_module called for: urllib3.fields [assertion]
+      find_module called for: mimetypes [assertion]
+      find_module called for: winreg [assertion]
+      find_module called for: urllib3.packages.six.moves.urllib [assertion]
+      find_module called for: urllib3.packages.six.moves.urllib.parse [assertion]
+      find_module called for: urllib3.response [assertion]
+      find_module called for: urllib3.poolmanager [assertion]
+      find_module called for: chardet [assertion]
+      find_module called for: chardet.compat [assertion]
+      find_module called for: chardet.universaldetector [assertion]
+      find_module called for: chardet.charsetgroupprober [assertion]
+      find_module called for: chardet.enums [assertion]
+      find_module called for: chardet.charsetprober [assertion]
+      find_module called for: chardet.escprober [assertion]
+      find_module called for: chardet.codingstatemachine [assertion]
+      find_module called for: chardet.escsm [assertion]
+      find_module called for: chardet.latin1prober [assertion]
+      find_module called for: chardet.mbcsgroupprober [assertion]
+      find_module called for: chardet.utf8prober [assertion]
+      find_module called for: chardet.mbcssm [assertion]
+      find_module called for: chardet.sjisprober [assertion]
+      find_module called for: chardet.mbcharsetprober [assertion]
+      find_module called for: chardet.chardistribution [assertion]
+      find_module called for: chardet.euctwfreq [assertion]
+      find_module called for: chardet.euckrfreq [assertion]
+      find_module called for: chardet.gb2312freq [assertion]
+      find_module called for: chardet.big5freq [assertion]
+      find_module called for: chardet.jisfreq [assertion]
+      find_module called for: chardet.jpcntx [assertion]
+      find_module called for: chardet.eucjpprober [assertion]
+      find_module called for: chardet.gb2312prober [assertion]
+      find_module called for: chardet.euckrprober [assertion]
+      find_module called for: chardet.cp949prober [assertion]
+      find_module called for: chardet.big5prober [assertion]
+      find_module called for: chardet.euctwprober [assertion]
+      find_module called for: chardet.sbcsgroupprober [assertion]
+      find_module called for: chardet.sbcharsetprober [assertion]
+      find_module called for: chardet.langcyrillicmodel [assertion]
+      find_module called for: chardet.langgreekmodel [assertion]
+      find_module called for: chardet.langbulgarianmodel [assertion]
+      find_module called for: chardet.langthaimodel [assertion]
+      find_module called for: chardet.langhebrewmodel [assertion]
+      find_module called for: chardet.hebrewprober [assertion]
+      find_module called for: chardet.langturkishmodel [assertion]
+      find_module called for: chardet.version [assertion]
+      find_module called for: requests.exceptions [assertion]
+      find_module called for: urllib3.contrib [assertion]
+      find_module called for: urllib3.contrib.pyopenssl [assertion]
+      find_module called for: OpenSSL [assertion]
+      find_module called for: requests.__version__ [assertion]
+      find_module called for: requests.utils [assertion]
+      find_module called for: cgi [assertion]
+      find_module called for: html [assertion]
+      find_module called for: html.entities [assertion]
+      find_module called for: requests.certs [assertion]
+      find_module called for: certifi [assertion]
+      find_module called for: certifi.core [assertion]
+      find_module called for: requests._internal_utils [assertion]
+      find_module called for: requests.compat [assertion]
+      find_module called for: simplejson [assertion]
+      find_module called for: decimal [assertion]
+      find_module called for: _decimal [assertion]
+      find_module called for: numbers [assertion]
+      find_module called for: simplejson.scanner [assertion]
+      find_module called for: simplejson._speedups [assertion]
+      find_module called for: simplejson.decoder [assertion]
+      find_module called for: simplejson.compat [assertion]
+      find_module called for: simplejson.encoder [assertion]
+      find_module called for: urllib.request [assertion]
+      find_module called for: urllib.error [assertion]
+      find_module called for: urllib.response [assertion]
+      find_module called for: http.cookiejar [assertion]
+      find_module called for: http.cookies [assertion]
+      find_module called for: requests.cookies [assertion]
+      find_module called for: requests.structures [assertion]
+      find_module called for: requests.packages [assertion]
+      find_module called for: idna [assertion]
+      find_module called for: idna.package_data [assertion]
+      find_module called for: idna.core [assertion]
+      find_module called for: idna.idnadata [assertion]
+      find_module called for: unicodedata [assertion]
+      find_module called for: idna.intranges [assertion]
+      find_module called for: requests.models [assertion]
+      find_module called for: encodings.idna [assertion]
+      find_module called for: stringprep [assertion]
+      find_module called for: requests.hooks [assertion]
+      find_module called for: requests.auth [assertion]
+      find_module called for: requests.status_codes [assertion]
+      find_module called for: requests.api [assertion]
+      find_module called for: requests.sessions [assertion]
+      find_module called for: requests.adapters [assertion]
+      find_module called for: urllib3.contrib.socks [assertion]
+      find_module called for: socks [assertion]
+      find_module called for: theblues.errors [assertion]
+      find_module called for: theblues.utils [assertion]
+      find_module called for: urllib.urlencode [assertion]
+      find_module called for: juju.tag [assertion]
+      find_module called for: juju.utils [assertion]
+      find_module called for: juju.client [assertion]
+      find_module called for: juju.client.client [assertion]
+      find_module called for: juju.client._client [assertion]
+      find_module called for: juju.client._definitions [assertion]
+      find_module called for: juju.client.facade [assertion]
+      find_module called for: typing [assertion]
+      find_module called for: juju.client.codegen [assertion]
+      find_module called for: juju.client._client1 [assertion]
+      find_module called for: juju.client._client2 [assertion]
+      find_module called for: juju.client._client3 [assertion]
+      find_module called for: juju.client._client4 [assertion]
+      find_module called for: juju.client._client5 [assertion]
+      find_module called for: juju.client.overrides [assertion]
+      find_module called for: juju.client.connection [assertion]
+      find_module called for: juju.errors [assertion]
+      find_module called for: juju.constraints [assertion]
+      find_module called for: juju.delta [assertion]
+      find_module called for: juju.exceptions [assertion]
+      find_module called for: juju.placement [assertion]
+      find_module called for: utils [assertion]
+      matched marked file 'utils' (from 'utils') [assertion]
+      found cached rewritten pyc for '/home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/utils.py' [assertion]
+      find_module called for: asyncio_extras [assertion]
+      find_module called for: asyncio_extras.asyncyield [assertion]
+      find_module called for: async_generator [assertion]
+      find_module called for: async_generator.impl [assertion]
+      find_module called for: async_generator.util [assertion]
+      find_module called for: asyncio_extras.contextmanager [assertion]
+      find_module called for: asyncio_extras.file [assertion]
+      find_module called for: asyncio_extras.threads [assertion]
+      find_module called for: gc [assertion]
+      find_module called for: asyncio_extras.generator [assertion]
+      find_module called for: juju.controller [assertion]
+      find_module called for: logger [assertion]
+      find_module called for: validation [assertion]
+      matched marked file 'validation' (from 'validation') [assertion]
+      _read_pyc(/home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/validation.py): invalid or out of date pyc [assertion]
+      rewriting '/home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/validation.py' [assertion]
+        pytest_pycollect_makeitem [hook]
+            obj: /home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/__pycache__/test_live_model.cpython-35-PYTEST.pyc
+            collector: <Module 'test_live_model.py'>
+            name: __cached__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <function log_calls_async.<locals>.wrapper at 0x7fd16d794488>
+            collector: <Module 'test_live_model.py'>
+            name: wait_for_ready
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: test_live_model
+            collector: <Module 'test_live_model.py'>
+            name: __name__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: ModuleSpec(name='test_live_model', loader=<_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>)
+            collector: <Module 'test_live_model.py'>
+            name: __spec__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <class 'juju.model.Model'>
+            collector: <Module 'test_live_model.py'>
+            name: Model
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <module 'builtins' (built-in)>
+            collector: <Module 'test_live_model.py'>
+            name: @py_builtins
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <function test_live_model at 0x7fd16f20b400>
+            collector: <Module 'test_live_model.py'>
+            name: test_live_model
+          pytest_generate_tests [hook]
+              metafunc: <_pytest.python.Metafunc object at 0x7fd16d767a20>
+          finish pytest_generate_tests --> [] [hook]
+        finish pytest_pycollect_makeitem --> [<Function 'test_live_model'>] [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <module '_pytest.assertion.rewrite' from '/usr/local/lib/python3.5/dist-packages/_pytest/assertion/rewrite.py'>
+            collector: <Module 'test_live_model.py'>
+            name: @pytest_ar
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <function log_calls_async.<locals>.wrapper at 0x7fd16d796510>
+            collector: <Module 'test_live_model.py'>
+            name: validate_all
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <module 'pytest' from '/usr/local/lib/python3.5/dist-packages/pytest.py'>
+            collector: <Module 'test_live_model.py'>
+            name: pytest
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <_pytest.assertion.rewrite.AssertionRewritingHook object at 0x7fd16ff957b8>
+            collector: <Module 'test_live_model.py'>
+            name: __loader__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: /home/jackal/workspace/charms/kubernetes-jenkins/integration-tests/test_live_model.py
+            collector: <Module 'test_live_model.py'>
+            name: __file__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: 
+            collector: <Module 'test_live_model.py'>
+            name: __package__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <function captured_fail_logs at 0x7fd16d792f28>
+            collector: <Module 'test_live_model.py'>
+            name: captured_fail_logs
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: None
+            collector: <Module 'test_live_model.py'>
+            name: __doc__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: {'TabError': <class 'TabError'>, 'ArithmeticError': <class 'ArithmeticError'>, 'ProcessLookupError': <class 'ProcessLookupError'>, 'object': <class 'object'>, 'dir': <built-in function dir>, 'getattr': <built-in function getattr>, 'pow': <built-in function pow>, 'staticmethod': <class 'staticmethod'>, 'isinstance': <built-in function isinstance>, 'memoryview': <class 'memoryview'>, 'IsADirectoryError': <class 'IsADirectoryError'>, 'delattr': <built-in function delattr>, 'DeprecationWarning': <class 'DeprecationWarning'>, 'ord': <built-in function ord>, 'print': <built-in function print>, 'bool': <class 'bool'>, 'property': <class 'property'>, 'ConnectionError': <class 'ConnectionError'>, 'PermissionError': <class 'PermissionError'>, 'OSError': <class 'OSError'>, 'list': <class 'list'>, '__name__': 'builtins', 'RuntimeError': <class 'RuntimeError'>, 'bytearray': <class 'bytearray'>, 'FloatingPointError': <class 'FloatingPointError'>, 'quit': Use quit() or Ctrl-D (i.e. EOF) to exit, 'SystemExit': <class 'SystemExit'>, 'setattr': <built-in function setattr>, 'BytesWarning': <class 'BytesWarning'>, 'tuple': <class 'tuple'>, 'map': <class 'map'>, 'TypeError': <class 'TypeError'>, 'GeneratorExit': <class 'GeneratorExit'>, 'ImportError': <class 'ImportError'>, 'ChildProcessError': <class 'ChildProcessError'>, 'FutureWarning': <class 'FutureWarning'>, 'FileExistsError': <class 'FileExistsError'>, 'ConnectionResetError': <class 'ConnectionResetError'>, 'True': True, 'locals': <built-in function locals>, 'SyntaxError': <class 'SyntaxError'>, 'TimeoutError': <class 'TimeoutError'>, 'LookupError': <class 'LookupError'>, 'copyright': Copyright (c) 2001-2016 Python Software Foundation.
+All Rights Reserved.
+
+Copyright (c) 2000 BeOpen.com.
+All Rights Reserved.
+
+Copyright (c) 1995-2001 Corporation for National Research Initiatives.
+All Rights Reserved.
+
+Copyright (c) 1991-1995 Stichting Mathematisch Centrum, Amsterdam.
+All Rights Reserved., 'FileNotFoundError': <class 'FileNotFoundError'>, 'int': <class 'int'>, '__build_class__': <built-in function __build_class__>, 'InterruptedError': <class 'InterruptedError'>, 'ImportWarning': <class 'ImportWarning'>, 'OverflowError': <class 'OverflowError'>, 'open': <built-in function open>, 'input': <built-in function input>, 'license': Type license() to see the full license text, 'id': <built-in function id>, 'Warning': <class 'Warning'>, 'BufferError': <class 'BufferError'>, '__package__': '', 'SystemError': <class 'SystemError'>, 'sorted': <built-in function sorted>, 'float': <class 'float'>, 'hash': <built-in function hash>, 'len': <built-in function len>, 'IOError': <class 'OSError'>, 'BlockingIOError': <class 'BlockingIOError'>, 'NotImplementedError': <class 'NotImplementedError'>, 'RuntimeWarning': <class 'RuntimeWarning'>, 'ascii': <built-in function ascii>, 'ValueError': <class 'ValueError'>, 'NameError': <class 'NameError'>, 'UnicodeTranslateError': <class 'UnicodeTranslateError'>, 'ResourceWarning': <class 'ResourceWarning'>, 'KeyboardInterrupt': <class 'KeyboardInterrupt'>, 'iter': <built-in function iter>, 'UnicodeDecodeError': <class 'UnicodeDecodeError'>, 'eval': <built-in function eval>, 'bytes': <class 'bytes'>, 'KeyError': <class 'KeyError'>, 'StopIteration': <class 'StopIteration'>, 'str': <class 'str'>, 'StopAsyncIteration': <class 'StopAsyncIteration'>, 'filter': <class 'filter'>, 'complex': <class 'complex'>, 'callable': <built-in function callable>, 'SyntaxWarning': <class 'SyntaxWarning'>, 'exec': <built-in function exec>, 'UnicodeError': <class 'UnicodeError'>, 'chr': <built-in function chr>, 'all': <built-in function all>, 'max': <built-in function max>, 'oct': <built-in function oct>, 'NotImplemented': NotImplemented, 'classmethod': <class 'classmethod'>, 'PendingDeprecationWarning': <class 'PendingDeprecationWarning'>, 'format': <built-in function format>, 'issubclass': <built-in function issubclass>, 'hex': <built-in function hex>, 'AttributeError': <class 'AttributeError'>, 'ConnectionAbortedError': <class 'ConnectionAbortedError'>, 'IndexError': <class 'IndexError'>, 'next': <built-in function next>, 'super': <class 'super'>, 'range': <class 'range'>, 'UnicodeWarning': <class 'UnicodeWarning'>, 'NotADirectoryError': <class 'NotADirectoryError'>, 'min': <built-in function min>, 'EnvironmentError': <class 'OSError'>, 'hasattr': <built-in function hasattr>, 'Ellipsis': Ellipsis, 'zip': <class 'zip'>, 'ConnectionRefusedError': <class 'ConnectionRefusedError'>, 'dict': <class 'dict'>, 'repr': <built-in function repr>, 'exit': Use exit() or Ctrl-D (i.e. EOF) to exit, 'UserWarning': <class 'UserWarning'>, '__doc__': "Built-in functions, exceptions, and other objects.\n\nNoteworthy: None is the `nil' object; Ellipsis represents `...' in slices.", 'MemoryError': <class 'MemoryError'>, 'reversed': <class 'reversed'>, 'credits':     Thanks to CWI, CNRI, BeOpen.com, Zope Corporation and a cast of thousands
+    for supporting Python development.  See www.python.org for more information., 'round': <built-in function round>, 'set': <class 'set'>, 'AssertionError': <class 'AssertionError'>, 'ReferenceError': <class 'ReferenceError'>, 'RecursionError': <class 'RecursionError'>, 'BaseException': <class 'BaseException'>, 'False': False, '__import__': <built-in function __import__>, 'globals': <built-in function globals>, 'help': Type help() for interactive help, or help(object) for help about object., 'enumerate': <class 'enumerate'>, 'bin': <built-in function bin>, '__loader__': <class '_frozen_importlib.BuiltinImporter'>, 'vars': <built-in function vars>, 'BrokenPipeError': <class 'BrokenPipeError'>, 'UnboundLocalError': <class 'UnboundLocalError'>, 'Exception': <class 'Exception'>, 'IndentationError': <class 'IndentationError'>, 'compile': <built-in function compile>, 'sum': <built-in function sum>, 'divmod': <built-in function divmod>, 'any': <built-in function any>, 'UnicodeEncodeError': <class 'UnicodeEncodeError'>, 'abs': <built-in function abs>, 'EOFError': <class 'EOFError'>, '__spec__': ModuleSpec(name='builtins', loader=<class '_frozen_importlib.BuiltinImporter'>), 'ZeroDivisionError': <class 'ZeroDivisionError'>, 'slice': <class 'slice'>, 'type': <class 'type'>, 'frozenset': <class 'frozenset'>, '__debug__': True, 'None': None}
+            collector: <Module 'test_live_model.py'>
+            name: __builtins__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__init__' of 'module' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __init__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__setattr__' of 'module' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __setattr__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <method '__dir__' of 'module' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __dir__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__getattribute__' of 'module' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __getattribute__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <built-in method __new__ of type object at 0xa3b980>
+            collector: <Module 'test_live_model.py'>
+            name: __new__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <member '__dict__' of 'module' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __dict__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__delattr__' of 'module' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __delattr__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__repr__' of 'module' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __repr__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__eq__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __eq__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <method '__reduce__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __reduce__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__gt__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __gt__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__lt__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __lt__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <attribute '__class__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __class__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <method '__format__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __format__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__ne__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __ne__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__str__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __str__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__le__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __le__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <method '__sizeof__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __sizeof__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <method '__reduce_ex__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __reduce_ex__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <method '__subclasshook__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __subclasshook__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__ge__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __ge__
+        finish pytest_pycollect_makeitem --> None [hook]
+        pytest_pycollect_makeitem [hook]
+            obj: <slot wrapper '__hash__' of 'object' objects>
+            collector: <Module 'test_live_model.py'>
+            name: __hash__
+        finish pytest_pycollect_makeitem --> None [hook]
+      finish pytest_make_collect_report --> <CollectReport 'test_live_model.py' lenresult=1 outcome='passed'> [hook]
+    genitems <Function 'test_live_model'> [collection]
+      pytest_itemcollected [hook]
+          item: <Function 'test_live_model'>
+      finish pytest_itemcollected --> [] [hook]
+      pytest_collectreport [hook]
+          report: <CollectReport 'test_live_model.py' lenresult=1 outcome='passed'>
+      finish pytest_collectreport --> [] [hook]
+      pytest_collection_modifyitems [hook]
+          config: <_pytest.config.Config object at 0x7fd170f87588>
+          items: [<Function 'test_live_model'>]
+          session: <Session 'integration-tests'>
+      finish pytest_collection_modifyitems --> [] [hook]
+      pytest_collection_finish [hook]
+          session: <Session 'integration-tests'>
+        pytest_report_collectionfinish [hook]
+            config: <_pytest.config.Config object at 0x7fd170f87588>
+            startdir: /home/jackal/workspace/charms/kubernetes-jenkins/integration-tests
+            items: [<Function 'test_live_model'>]
+        finish pytest_report_collectionfinish --> [] [hook]
+      finish pytest_collection_finish --> [] [hook]
+    finish pytest_collection --> [<Function 'test_live_model'>] [hook]
+    pytest_runtestloop [hook]
+        session: <Session 'integration-tests'>
+      pytest_runtest_protocol [hook]
+          nextitem: None
+          item: <Function 'test_live_model'>
+        pytest_runtest_logstart [hook]
+            location: ('test_live_model.py', 9, 'test_live_model')
+            nodeid: test_live_model.py::test_live_model
+        finish pytest_runtest_logstart --> [] [hook]
+        pytest_runtest_setup [hook]
+            item: <Function 'test_live_model'>
+          pytest_fixture_setup [hook]
+              request: <SubRequest 'log_dir' for <Function 'test_live_model'>>
+              fixturedef: <FixtureDef name='log_dir' scope='function' baseid='' >
+          finish pytest_fixture_setup --> logs/test_live_model/test_live_model [hook]
+          pytest_fixture_setup [hook]
+              request: <SubRequest 'event_loop' for <Function 'test_live_model'>>
+              fixturedef: <FixtureDef name='event_loop' scope='function' baseid='' >
+          finish pytest_fixture_setup --> <_UnixSelectorEventLoop running=False closed=False debug=False> [hook]
+        finish pytest_runtest_setup --> [] [hook]
+        pytest_runtest_makereport [hook]
+            item: <Function 'test_live_model'>
+            call: <CallInfo when='setup' result: []>
+        finish pytest_runtest_makereport --> <TestReport 'test_live_model.py::test_live_model' when='setup' outcome='passed'> [hook]
+        pytest_runtest_logreport [hook]
+            report: <TestReport 'test_live_model.py::test_live_model' when='setup' outcome='passed'>
+          pytest_report_teststatus [hook]
+              report: <TestReport 'test_live_model.py::test_live_model' when='setup' outcome='passed'>
+          finish pytest_report_teststatus --> ('', '', '') [hook]
+        finish pytest_runtest_logreport --> [] [hook]
+        pytest_runtest_call [hook]
+            item: <Function 'test_live_model'>
+          pytest_pyfunc_call [hook]
+              pyfuncitem: <Function 'test_live_model'>
+          find_module called for: juju.annotation [assertion]
+          find_module called for: juju.relation [assertion]
+          find_module called for: juju.machine [assertion]
+          find_module called for: dateutil [assertion]
+          find_module called for: dateutil._version [assertion]
+          find_module called for: dateutil.parser [assertion]
+          find_module called for: six [assertion]
+          find_module called for: dateutil.relativedelta [assertion]
+          find_module called for: dateutil._common [assertion]
+          find_module called for: dateutil.tz [assertion]
+          find_module called for: dateutil.tz.tz [assertion]
+          find_module called for: dateutil.tz._common [assertion]
+          find_module called for: dateutil.tz.win [assertion]
+          find_module called for: six.moves [assertion]
+          find_module called for: six.moves.winreg [assertion]
+          find_module called for: juju.action [assertion]
+          find_module called for: juju.application [assertion]
+          find_module called for: juju.unit [assertion]
+    find_module called for: py._io.capture [assertion]
+    pytest_keyboard_interrupt [hook]
+        excinfo: /usr/lib/python3.5/selectors.py:441: KeyboardInterrupt
+    find_module called for: py._std [assertion]
+    find_module called for: py._io.saferepr [assertion]
+    find_module called for: repr [assertion]
+    finish pytest_keyboard_interrupt --> [] [hook]
+    pytest_sessionfinish [hook]
+        exitstatus: 2
+        session: <Session 'integration-tests'>
+      pytest_fixture_post_finalizer [hook]
+          fixturedef: <FixtureDef name='event_loop' scope='function' baseid='' >
+      finish pytest_fixture_post_finalizer --> [] [hook]
+      pytest_fixture_post_finalizer [hook]
+          fixturedef: <FixtureDef name='log_dir' scope='function' baseid='' >
+      finish pytest_fixture_post_finalizer --> [] [hook]
+      pytest_terminal_summary [hook]
+          exitstatus: 2
+          terminalreporter: <_pytest.terminal.TerminalReporter object at 0x7fd16f1f9438>
+      finish pytest_terminal_summary --> [] [hook]
+    finish pytest_sessionfinish --> [] [hook]
+    pytest_unconfigure [hook]
+        config: <_pytest.config.Config object at 0x7fd170f87588>
+    finish pytest_unconfigure --> [] [hook]
+  finish [config:tmpdir]

--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -577,7 +577,7 @@ async def validate_docker_logins(model):
 
     # Start with a clean environment
     await cleanup()
-    await run_until_success('mkdir /tmp/test-registry')
+    await run_until_success('mkdir -p /tmp/test-registry')
     await run_until_success('chown ubuntu:ubuntu /tmp/test-registry')
 
     # Create registry secret


### PR DESCRIPTION
**Heads up:** This is completely untested due to today's charm store outage.

This should _hopefully_ fix the failures we've been seeing with a timeout during `validate_docker_logins`.

The problem is that the `test-registry` container gets restarted sometimes, and since there is no volume mount for the registry data, it loses any images that were uploaded to it. Since the `ubuntu` image is lost, `test-registry-user` gets stuck in a Pending state.

The fix is to add an `emptyDir` volume to `test-registry`, mounted at `/var/lib/registry`. This will allow the data to survive container restarts.

My original assessment that the Pod was getting rescheduled to a different Node is wrong. Pods don't change nodes. With that in mind, I've removed the `nodeSelector` because it accomplishes nothing.