### PR TITLE
increase timeouts

### DIFF
--- a/integration-tests/utils.py
+++ b/integration-tests/utils.py
@@ -137,7 +137,7 @@ def apply_profile(model_name):
 
 
 @async_contextmanager
-async def temporary_model(log_dir, timeout=7200, force_cloud=''):
+async def temporary_model(log_dir, timeout=14400, force_cloud=''):
     ''' Create and destroy a temporary Juju model named cdk-build-upgrade-*.
 
     This is an async context, to be used within an `async with` statement.

--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -343,7 +343,7 @@ async def validate_extra_args(model):
 
         await app.set_config(new_config)
 
-        with timeout_for_current_task(180):
+        with timeout_for_current_task(600):
             for service, expected_service_args in expected_args.items():
                 while True:
                     args_per_unit = await get_service_args(app, service)
@@ -357,7 +357,7 @@ async def validate_extra_args(model):
         }
         await app.set_config(filtered_original_config)
 
-        with timeout_for_current_task(180):
+        with timeout_for_current_task(600):
             for service, original_service_args in original_args.items():
                 while True:
                     new_args = await get_service_args(app, service)
@@ -469,7 +469,7 @@ async def validate_sans(model):
         await lb.set_config({'extra_sans': example_domain})
 
     # wait for server certs to update
-    deadline = time.time() + 180
+    deadline = time.time() + 600
     while time.time() < deadline:
         certs = await get_server_certs()
         if all(example_domain in cert for cert in certs):
@@ -484,7 +484,7 @@ async def validate_sans(model):
         await lb.set_config({'extra_sans': ''})
 
     # verify it went away
-    deadline = time.time() + 180
+    deadline = time.time() + 600
     while time.time() < deadline:
         certs = await get_server_certs()
         if not any(example_domain in cert for cert in certs):


### PR DESCRIPTION
Bump the model timeout from 2h to 4h:
- the e2e runs in 1.9.6 take longer to execute, and we run these for each `test-*`, so give them plenty of time to finish.

Bump the validator tests from 3m to 10m:
- changes are taking ~4 minutes for the cluster to settle after the k8s-e2e charm is deployed; double that and add 2 for a reasonable timeout.