### PR TITLE
install charm-tools with snapd

### DIFF
--- a/integration-tests/install-deps.sh
+++ b/integration-tests/install-deps.sh
@@ -5,8 +5,9 @@ set -eux
 # Can be run again to upgrade dependencies.
 
 sudo apt update -yq
-sudo apt install -y unzip python3-pip python-pip squashfuse snapd charm-tools
+sudo apt install -y unzip python3-pip python-pip squashfuse snapd
 sudo snap install juju --classic
+sudo snap install charm
 sudo snap install conjure-up --classic
 sudo pip2 install 'git+https://github.com/juju/juju-crashdump'
 sudo pip2 install -U pyopenssl bundletester


### PR DESCRIPTION
Replace the `charm-tools` deb with a `charm` snap.  The former brings in a bunch of junk.  The latter does too, but it's in a giant black box, so it bothers me less.

Also the `charm-tools` deb is no longer maintained/updated/recommended.