### PR TITLE
Making network policy test more robust.

### DIFF
--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -257,9 +257,7 @@ async def verify_ready(unit, entity_type, name_list, extra_args=''):
                 found_names += 1
             else:
                 return False
-    if found_names == len(name_list):
-        return True
-    return False
+    return found_names == len(name_list)
 
 
 @log_calls_async


### PR DESCRIPTION
I don't know how we can get in here with the namespace existing, but if we did we would explode trying to create the pods since the namespace was being deleted. Further, if it took longer than 10 seconds for the pods to come up, we could fail as well.