### PR TITLE
Use charm publish vs release

### DIFF
--- a/charms/build-and-release-bundles.sh
+++ b/charms/build-and-release-bundles.sh
@@ -9,7 +9,7 @@ release-bundle() {
   CS_PATH="$2"
   PUSH_CMD="/usr/bin/charm push $LOCAL_PATH $CS_PATH"
   REVISION=`${PUSH_CMD} | tail -n +1 | head -1 | awk '{print $2}'`
-  /usr/bin/charm release --channel edge ${REVISION}
+  /usr/bin/charm publish --channel edge ${REVISION}
 }
 
 bundle/bundle -o ./bundles/cdk-flannel -c edge k8s/cdk cni/flannel

--- a/charms/promote-charm.sh
+++ b/charms/promote-charm.sh
@@ -26,5 +26,5 @@ for resource in $RESOURCES; do
 done
 
 (set +u # allows expansion of empty RESOURCE_ARGS
-  charm release "$CHARM_ID" --channel "$TO_CHANNEL" "${RESOURCE_ARGS[@]}"
+  charm publish "$CHARM_ID" --channel "$TO_CHANNEL" "${RESOURCE_ARGS[@]}"
 )


### PR DESCRIPTION
The apt repo we are using for charm-tools has the charm publish instead of the charm release. :(