### PR TITLE
Support EKS snaps

### DIFF
--- a/snaps/build-and-release-aws-eks-snaps.sh
+++ b/snaps/build-and-release-aws-eks-snaps.sh
@@ -17,15 +17,11 @@ rm -rf ./release
 git clone https://github.com/juju-solutions/release.git --branch rye/snaps --depth 1
 (cd release/snap
   make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH="$KUBE_ARCH" \
-    targets="kubectl kubelet kube-proxy"
-  make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH="amd64" \
-    targets="kubernetes-test"
+    targets="kubectl kubelet kube-proxy kubernetes-test"
 )
 
-for app in kubectl kubelet kube-proxy; do
+for app in kubectl kubelet kube-proxy kubernetes-test; do
   for arch in $KUBE_ARCH; do
     retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${arch}.snap --release ${MAIN_VERSION}/${EKS_RELEASE}
   done
 done
-
-retry snapcraft push release/snap/build/kubernetes-test_${KUBE_VERSION:1}_amd64.snap --release ${MAIN_VERSION}/${EKS_RELEASE}

--- a/snaps/build-and-release-aws-eks-snaps.sh
+++ b/snaps/build-and-release-aws-eks-snaps.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+
+# This script will build and release snaps for AWS EKS.
+set -eux
+
+EKS_RELEASE="${EKS_RELEASE:-edge/eks.0}"
+KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
+KUBE_ARCH="amd64"
+
+source utilities.sh
+MAIN_VERSION=$(get_major_minor $KUBE_VERSION)
+
+source utils/retry.sh
+
+rm -rf ./release
+git clone https://github.com/juju-solutions/release.git --branch rye/snaps --depth 1
+(cd release/snap
+  make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH="$KUBE_ARCH" \
+    targets="kubectl kubelet kube-proxy"
+  make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH="amd64" \
+    targets="kubernetes-test"
+)
+
+for app in kubectl kubelet kube-proxy; do
+  for arch in $KUBE_ARCH; do
+    retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${arch}.snap --release ${MAIN_VERSION}/${EKS_RELEASE}
+  done
+done
+
+retry snapcraft push release/snap/build/kubernetes-test_${KUBE_VERSION:1}_amd64.snap --release ${MAIN_VERSION}/${EKS_RELEASE}

--- a/snaps/promote-snaps.sh
+++ b/snaps/promote-snaps.sh
@@ -6,7 +6,7 @@ set -eu
 # export PROMOTE_TO="1.6/beta 1.6/candidate edge beta candidate"
 # snaps/promote-snaps.sh
 
-SNAPS="kubectl kube-apiserver kube-controller-manager kube-scheduler kubelet kube-proxy cdk-addons kubeadm kubernetes-test"
+SNAPS="${SNAPS:-kubectl kube-apiserver kube-controller-manager kube-scheduler kubelet kube-proxy cdk-addons kubeadm kubernetes-test}"
 
 ARCH=${KUBE_ARCH:-"amd64"}
 echo PROMOTE_FROM="$PROMOTE_FROM"


### PR DESCRIPTION
For EKS, we want a subset of k8s snaps locked to the EKS k8s-master version.  Handle this with a new jenkins job that builds and releases "kubectl kubelet kube-proxy kubernetes-test" to a special eks channel.

Also update our promote-snaps job so we can specify a snap list (useful when we want to promote the eks subset).