### PR TITLE
Update tests to not assume apt installed charm

### DIFF
--- a/charms/build-and-release-bundles.sh
+++ b/charms/build-and-release-bundles.sh
@@ -29,8 +29,8 @@ if [ "$RUN_TESTS" = "true" ]; then
     export TEST_CHARM_CHANNEL=edge
     pytest --no-print-logs --junit-xml=report.xml test_cdk.py
   )
-fi
 
-export FROM_CHANNEL=edge
-export TO_CHANNEL=beta
-./charms/promote-all-charms-and-bundles.sh
+  export FROM_CHANNEL=edge
+  export TO_CHANNEL=beta
+  ./charms/promote-all-charms-and-bundles.sh
+fi

--- a/charms/build-and-release-bundles.sh
+++ b/charms/build-and-release-bundles.sh
@@ -7,9 +7,9 @@ git clone ${BUNDLE_REPOSITORY} bundle
 release-bundle() {
   LOCAL_PATH="$1"
   CS_PATH="$2"
-  PUSH_CMD="/usr/bin/charm push $LOCAL_PATH $CS_PATH"
+  PUSH_CMD="charm push $LOCAL_PATH $CS_PATH"
   REVISION=`${PUSH_CMD} | tail -n +1 | head -1 | awk '{print $2}'`
-  /usr/bin/charm release --channel edge ${REVISION}
+  charm release --channel edge ${REVISION}
 }
 
 bundle/bundle -o ./bundles/cdk-flannel -c edge k8s/cdk cni/flannel
@@ -27,10 +27,10 @@ release-bundle ./bundles/cdk-canal cs:~containers/bundle/canonical-kubernetes-ca
 if [ "$RUN_TESTS" = "true" ]; then
   (cd integration-tests
     export TEST_CHARM_CHANNEL=edge
-    pytest --junit-xml=report.xml test_cdk.py
+    pytest --no-print-logs --junit-xml=report.xml test_cdk.py
   )
-
-  export FROM_CHANNEL=edge
-  export TO_CHANNEL=beta
-  ./charms/promote-all-charms-and-bundles.sh
 fi
+
+export FROM_CHANNEL=edge
+export TO_CHANNEL=beta
+./charms/promote-all-charms-and-bundles.sh

--- a/charms/build-and-release-calico.sh
+++ b/charms/build-and-release-calico.sh
@@ -11,6 +11,9 @@ echo "${0} started at `date`."
 export JUJU_REPOSITORY=${WORKSPACE}/build/charms
 mkdir -p ${JUJU_REPOSITORY}
 
+export TMPDIR=${WORKSPACE}/tmp
+mkdir -p ${TMPDIR}
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"google"}
 
@@ -47,7 +50,7 @@ fi
 touch report.xml
 
 if [ ${RELEASE} = true ]; then
-  CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/calico cs:~containers/calico | head -n 1 | awk '{print $2}')
+  CHARM=$(charm push $JUJU_REPOSITORY/builds/calico cs:~containers/calico | head -n 1 | awk '{print $2}')
   charm set ${CHARM} commit=${COMMIT_HASH}
   echo "Releasing ${CHARM}"
   CHARM="$CHARM" FROM_CHANNEL=unpublished TO_CHANNEL=edge ./charms/promote-charm.sh

--- a/charms/build-and-release-canal.sh
+++ b/charms/build-and-release-canal.sh
@@ -11,6 +11,9 @@ echo "${0} started at `date`."
 export JUJU_REPOSITORY=${WORKSPACE}/build/charms
 mkdir -p ${JUJU_REPOSITORY}
 
+export TMPDIR=${WORKSPACE}/tmp
+mkdir -p ${TMPDIR}
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"google"}
 
@@ -47,7 +50,7 @@ fi
 touch report.xml
 
 if [ ${RELEASE} = true ]; then
-  CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/canal cs:~containers/canal | head -n 1 | awk '{print $2}')
+  CHARM=$(charm push $JUJU_REPOSITORY/builds/canal cs:~containers/canal | head -n 1 | awk '{print $2}')
   charm set ${CHARM} commit=${COMMIT_HASH}
   echo "Releasing ${CHARM}"
   CHARM="$CHARM" FROM_CHANNEL=unpublished TO_CHANNEL=edge ./charms/promote-charm.sh

--- a/charms/build-and-release-easyrsa.sh
+++ b/charms/build-and-release-easyrsa.sh
@@ -11,6 +11,9 @@ echo "${0} started at `date`."
 export JUJU_REPOSITORY=${WORKSPACE}/build/charms
 mkdir -p ${JUJU_REPOSITORY}
 
+export TMPDIR=${WORKSPACE}/tmp
+mkdir -p ${TMPDIR}
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"google"}
 
@@ -47,7 +50,7 @@ fi
 touch report.xml
 
 if [ ${RELEASE} = true ]; then
-  CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/easyrsa cs:~containers/easyrsa | head -n 1 | awk '{print $2}')
+  CHARM=$(charm push $JUJU_REPOSITORY/builds/easyrsa cs:~containers/easyrsa | head -n 1 | awk '{print $2}')
   charm set ${CHARM} commit=${COMMIT_HASH}
   echo "Releasing ${CHARM}"
   CHARM="$CHARM" FROM_CHANNEL=unpublished TO_CHANNEL=edge ./charms/promote-charm.sh

--- a/charms/build-and-release-etcd.sh
+++ b/charms/build-and-release-etcd.sh
@@ -11,6 +11,9 @@ echo "${0} started at `date`."
 export JUJU_REPOSITORY=${WORKSPACE}/build/charms
 mkdir -p ${JUJU_REPOSITORY}
 
+export TMPDIR=${WORKSPACE}/tmp
+mkdir -p ${TMPDIR}
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"google"}
 
@@ -47,7 +50,7 @@ fi
 touch report.xml
 
 if [ ${RELEASE} = true ]; then
-  CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/etcd cs:~containers/etcd | head -n 1 | awk '{print $2}')
+  CHARM=$(charm push $JUJU_REPOSITORY/builds/etcd cs:~containers/etcd | head -n 1 | awk '{print $2}')
   charm set ${CHARM} commit=${COMMIT_HASH}
   echo "Releasing ${CHARM}"
   CHARM="$CHARM" FROM_CHANNEL=unpublished TO_CHANNEL=edge ./charms/promote-charm.sh

--- a/charms/build-and-release-flannel.sh
+++ b/charms/build-and-release-flannel.sh
@@ -11,6 +11,9 @@ echo "${0} started at `date`."
 export JUJU_REPOSITORY=${WORKSPACE}/build/charms
 mkdir -p ${JUJU_REPOSITORY}
 
+export TMPDIR=${WORKSPACE}/tmp
+mkdir -p ${TMPDIR}
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"google"}
 
@@ -47,7 +50,7 @@ fi
 touch report.xml
 
 if [ ${RELEASE} = true ]; then
-  CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/flannel cs:~containers/flannel | head -n 1 | awk '{print $2}')
+  CHARM=$(charm push $JUJU_REPOSITORY/builds/flannel cs:~containers/flannel | head -n 1 | awk '{print $2}')
   charm set ${CHARM} commit=${COMMIT_HASH}
   echo "Releasing ${CHARM}"
   CHARM="$CHARM" FROM_CHANNEL=unpublished TO_CHANNEL=edge ./charms/promote-charm.sh

--- a/charms/build-and-release-kubeapi-load-balancer.sh
+++ b/charms/build-and-release-kubeapi-load-balancer.sh
@@ -11,6 +11,9 @@ echo "${0} started at `date`."
 export JUJU_REPOSITORY=${WORKSPACE}/build/charms
 mkdir -p ${JUJU_REPOSITORY}
 
+export TMPDIR=${WORKSPACE}/tmp
+mkdir -p ${TMPDIR}
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"google"}
 
@@ -49,7 +52,7 @@ fi
 touch report.xml
 
 if [ ${RELEASE} = true ]; then
-  CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/kubeapi-load-balancer cs:~containers/kubeapi-load-balancer | head -n 1 | awk '{print $2}')
+  CHARM=$(charm push $JUJU_REPOSITORY/builds/kubeapi-load-balancer cs:~containers/kubeapi-load-balancer | head -n 1 | awk '{print $2}')
   charm set ${CHARM} commit=${COMMIT_HASH}
   echo "Releasing ${CHARM}"
   CHARM="$CHARM" FROM_CHANNEL=unpublished TO_CHANNEL=edge ./charms/promote-charm.sh

--- a/charms/build-and-release-kubernetes-e2e.sh
+++ b/charms/build-and-release-kubernetes-e2e.sh
@@ -11,6 +11,9 @@ echo "${0} started at `date`."
 export JUJU_REPOSITORY=${WORKSPACE}/build/charms
 mkdir -p ${JUJU_REPOSITORY}
 
+export TMPDIR=${WORKSPACE}/tmp
+mkdir -p ${TMPDIR}
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"google"}
 
@@ -49,7 +52,7 @@ fi
 touch report.xml
 
 if [ ${RELEASE} = true ]; then
-  CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/kubernetes-e2e cs:~containers/kubernetes-e2e | head -n 1 | awk '{print $2}')
+  CHARM=$(charm push $JUJU_REPOSITORY/builds/kubernetes-e2e cs:~containers/kubernetes-e2e | head -n 1 | awk '{print $2}')
   charm set ${CHARM} commit=${COMMIT_HASH}
   echo "Releasing ${CHARM}"
   CHARM="$CHARM" FROM_CHANNEL=unpublished TO_CHANNEL=edge ./charms/promote-charm.sh

--- a/charms/build-and-release-kubernetes-master.sh
+++ b/charms/build-and-release-kubernetes-master.sh
@@ -11,6 +11,9 @@ echo "${0} started at `date`."
 export JUJU_REPOSITORY=${WORKSPACE}/build/charms
 mkdir -p ${JUJU_REPOSITORY}
 
+export TMPDIR=${WORKSPACE}/tmp
+mkdir -p ${TMPDIR}
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"google"}
 
@@ -49,7 +52,7 @@ fi
 touch report.xml
 
 if [ ${RELEASE} = true ]; then
-  CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/kubernetes-master cs:~containers/kubernetes-master | head -n 1 | awk '{print $2}')
+  CHARM=$(charm push $JUJU_REPOSITORY/builds/kubernetes-master cs:~containers/kubernetes-master | head -n 1 | awk '{print $2}')
   charm set ${CHARM} commit=${COMMIT_HASH}
   echo "Releasing ${CHARM}"
   CHARM="$CHARM" FROM_CHANNEL=unpublished TO_CHANNEL=edge ./charms/promote-charm.sh

--- a/charms/build-and-release-kubernetes-worker.sh
+++ b/charms/build-and-release-kubernetes-worker.sh
@@ -11,6 +11,9 @@ echo "${0} started at `date`."
 export JUJU_REPOSITORY=${WORKSPACE}/build/charms
 mkdir -p ${JUJU_REPOSITORY}
 
+export TMPDIR=${WORKSPACE}/tmp
+mkdir -p ${TMPDIR}
+
 # The cloud is an option for this script, default to gce.
 CLOUD=${CLOUD:-"google"}
 
@@ -49,7 +52,7 @@ fi
 touch report.xml
 
 if [ ${RELEASE} = true ]; then
-  CHARM=$(/usr/bin/charm push $JUJU_REPOSITORY/builds/kubernetes-worker cs:~containers/kubernetes-worker | head -n 1 | awk '{print $2}')
+  CHARM=$(charm push $JUJU_REPOSITORY/builds/kubernetes-worker cs:~containers/kubernetes-worker | head -n 1 | awk '{print $2}')
   charm set ${CHARM} commit=${COMMIT_HASH}
   echo "Releasing ${CHARM}"
   CHARM="$CHARM" FROM_CHANNEL=unpublished TO_CHANNEL=edge ./charms/promote-charm.sh


### PR DESCRIPTION
Fixing charm to not be forced path to the apt installed version.
Added TMPDIR environment variable to get charm tests under the home directory so snaps remain happy.

Jenkins is set to cleanup the workspace, but maybe I should nuke that tmp directory afterward?