### PR TITLE
Fixing format change in charm list-resources breaking promote scripts.

### DIFF
--- a/charms/promote-charm.sh
+++ b/charms/promote-charm.sh
@@ -19,7 +19,7 @@ fi
 CHARM_ID="$(charm show "$CHARM" --channel "$FROM_CHANNEL" id | grep Id: | awk '{print $2}')"
 
 declare -a RESOURCE_ARGS=()
-RESOURCES="$(charm list-resources "$CHARM_ID" --channel "$FROM_CHANNEL" | tail -n +3 | sed -e '/^$/d' -e 's/  */-/g')"
+RESOURCES="$(charm list-resources "$CHARM_ID" --channel "$FROM_CHANNEL" --format=short)"
 for resource in $RESOURCES; do
   RESOURCE_ARGS+=('-r')
   RESOURCE_ARGS+=("$resource")


### PR DESCRIPTION
`charm list-resources` dropped an output line. In researching, I found out about --format=short and it outputs in the format we want. Here's to hoping it doesn't change.