### PR TITLE
If a charm has no resources, the short format prints 'No resources found.'

### DIFF
--- a/charms/promote-charm.sh
+++ b/charms/promote-charm.sh
@@ -19,7 +19,7 @@ fi
 CHARM_ID="$(charm show "$CHARM" --channel "$FROM_CHANNEL" id | grep Id: | awk '{print $2}')"
 
 declare -a RESOURCE_ARGS=()
-RESOURCES="$(charm list-resources "$CHARM_ID" --channel "$FROM_CHANNEL" --format=short)"
+RESOURCES="$(charm list-resources "$CHARM_ID" --channel "$FROM_CHANNEL" --format=short | grep -v 'No resources found.')"
 for resource in $RESOURCES; do
   RESOURCE_ARGS+=('-r')
   RESOURCE_ARGS+=("$resource")


### PR DESCRIPTION
This caused use to think there were 3 resources: 'No', 'resources', 'found.'. This is sub-optimal so I am grepping it away.