### PR TITLE
Updating snap build script for betas, status and new tracks

### DIFF
--- a/snaps/build-and-release-snaps-on-new-release.sh
+++ b/snaps/build-and-release-snaps-on-new-release.sh
@@ -6,30 +6,30 @@ set -eux
 source utilities.sh
 
 # K8s versions we want to check for new releases
-declare -a VERSIONS=('1.6' '1.7' '1.8' '1.9' '1.10' '1.11' '2.0' 'latest');
+declare -a VERSIONS=('1.6' '1.7' '1.8' '1.9' '1.10' '1.11' '1.12' '1.13' '1.14' '2.0' 'latest');
+
+SNAP_INFO_KUBECTL=$(snap info kubectl)
+SNAPCRAFT_REVISIONS_KUBELET=$(snapcraft revisions --arch=amd64 kubelet)
 
 function check_for_release {
   # Sets $trigger to 'yes' when a new release is available.
-  # Looks inside $LAST_RELEASE_FILE and compares the contents with
-  # what is in $KUBE_VERSION
+  # Compares snap info on kubectl to find version information
 
-  trigger='no'
-  if [ -f $LAST_RELEASE_FILE ]
+  if [ "$BRANCH" == "latest" ]
   then
-    LAST_RELEASED=`cat $LAST_RELEASE_FILE`
-    if [ "$LAST_RELEASED" != "$KUBE_VERSION" ]
-    then
-      echo "New release ($KUBE_VERSION) detected."
-      trigger='yes'
-    else
-      echo "No new release detected. Latest release is $LAST_RELEASED."
-      trigger='no'
-    fi
+    LAST_RELEASE=$(grep ' edge:' <<< "${SNAP_INFO_KUBECTL}"|awk '{print $2}')
   else
-    echo "Bootstrapping trigger with kubernetes version $KUBE_VERSION."
-    echo "Releases following $KUBE_VERSION will trigger the snap release process."
-    echo "$KUBE_VERSION" > $LAST_RELEASE_FILE
-    trigger='init'
+    MAIN_VERSION=$(get_major_minor $KUBE_VERSION)
+    LAST_RELEASE=$(grep ${MAIN_VERSION}/edge <<< "${SNAP_INFO_KUBECTL}"|awk '{print $2}')
+  fi
+  trigger='no'
+  echo "Last release is ${LAST_RELEASE} and this release is ${KUBE_VERSION}"
+  if [ v$LAST_RELEASE != $KUBE_VERSION ]
+  then
+    echo "New release ($KUBE_VERSION) detected."
+    trigger='yes'
+  else
+    echo "No new release detected. Latest release is ${LAST_RELEASE}"
   fi
 }
 
@@ -51,39 +51,81 @@ function build_promote {
     export PROMOTE_TO="edge beta candidate $PROMOTE_TO"
   fi
   $scripts_path/promote-snaps.sh
-
-  # We are done with promoting the snaps. Lets mark the release.
-  echo "$KUBE_VERSION" > $LAST_RELEASE_FILE
 }
 
 function promote_stable {
   # Promotes to stable the release found in candidate.
   # The following conditions should hold:
-  # 1. $LAST_RELEASE_FILE should be the same the past 7 days AND
-  # 2. a) There was not previous release ($STABLE_RELEASED_FILE does not exist) OR
-  #    b) There is a new release ($LAST_RELEASE_FILE and $STABLE_RELEASED_FILE differ)
+  # 1. snap revision should be 7 days old(so no new revisions in 7 days) AND
+  # 2. a) There was not previous release OR
+  #    b) There is a new release
 
-  seven_days_ago=$(date -d 'now - 7 days' +%s)
-  last_release_time=$(date -r "$LAST_RELEASE_FILE" +%s)
   stable_promotion='no'
-  if (( last_release_time >= seven_days_ago))
+  if [ "$BRANCH" == "latest" ]
   then
-    echo "Release $KUBE_VERSION too young to promote to stable"
-  elif [ ! -f $STABLE_RELEASE_FILE ] || ! cmp --silent $LAST_RELEASE_FILE $STABLE_RELEASE_FILE
+    CURRENT_STABLE_RELEASE=$(grep ' stable:' <<< "${SNAP_INFO_KUBECTL}"|awk '{print $2}')
+  else
+    CURRENT_STABLE_RELEASE=$(grep ${MAIN_VERSION}/stable <<< "${SNAP_INFO_KUBECTL}"|awk '{print $2}')
+  fi
+  if [ v${CURRENT_STABLE_RELEASE} = ${KUBE_VERSION} ]
   then
-    echo "Promoting mature $KUBE_VERSION release to stable"
-    # Promote snaps from edge to candidate
-    scripts_path=$(dirname "$0")
-    version=$(get_major_minor $KUBE_VERSION)
-    export PROMOTE_FROM="$version/candidate"
-    export PROMOTE_TO="$version/stable"
+    echo 'nothing to promote!'
+  else
+    # ok, we have a new version, how old is it?
     if [ "$BRANCH" == "latest" ]
     then
-      export PROMOTE_TO="stable $PROMOTE_TO"
+      release_time_string=$(grep " edge\*"<<< "${SNAPCRAFT_REVISIONS_KUBELET}"|awk '{print $2}')
+    else
+      release_time_string=$(grep "${MAIN_VERSION}/edge\*"<<< "${SNAPCRAFT_REVISIONS_KUBELET}"|awk '{print $2}')
     fi
-    $scripts_path/promote-snaps.sh
+    release_time=$(date -d "${release_time_string} + 7 days" +%s)
+    right_now=$(date +%s)
+    if (( right_now >= release_time))
+    then
+      echo "Promoting mature $KUBE_VERSION release to stable"
+      # Promote snaps from edge to candidate
+      scripts_path=$(dirname "$0")
+      version=$(get_major_minor $KUBE_VERSION)
+      export PROMOTE_FROM="$version/candidate"
+      export PROMOTE_TO="$version/stable"
+      if [ "$BRANCH" == "latest" ]
+      then
+        export PROMOTE_TO="stable $PROMOTE_TO"
+      fi
+      $scripts_path/promote-snaps.sh
 
-    stable_promotion='yes'
+      stable_promotion='yes'
+    else
+	echo "Release $KUBE_VERSION too young to promote to stable"
+	echo "Will promote in $(( (release_time - right_now) / 86400 )) days"
+    fi
+  fi
+}
+
+
+function find_release {
+  # Finds a suitable release for this version(stable/beta/alpha)
+  if [ "$1" == "latest" ]
+  then
+    url="https://dl.k8s.io/release/stable.txt"
+  else
+    url="https://dl.k8s.io/release/stable-${BRANCH}.txt"
+  fi
+
+  export KUBE_VERSION="$(curl -s -L $url)"
+  export KUBE_VERSION_URL=$url
+
+  if [[ $KUBE_VERSION = *"Error"* ]]
+  then
+    if [ "$1" == "latest" ]
+    then
+      url="https://dl.k8s.io/release/latest.txt"
+    else
+      url="https://dl.k8s.io/release/latest-${BRANCH}.txt"
+    fi
+
+    export KUBE_VERSION="$(curl -s -L $url)"
+    export KUBE_VERSION_URL=$url
   fi
 }
 
@@ -91,18 +133,9 @@ function promote_stable {
 # Main loop. Go over all versions
 for BRANCH in ${VERSIONS[@]}
 do
-  if [ "$BRANCH" == "latest" ]
-  then
-    url="https://dl.k8s.io/release/stable.txt"
-  else
-    url="https://dl.k8s.io/release/stable-${BRANCH}.txt"
-  fi
+  find_release "${BRANCH}"
+
   export BRANCH
-  export KUBE_VERSION="$(curl -s -L $url)"
-  # LAST_RELEASE_FILE keeps the last release we did to candidate.
-  export LAST_RELEASE_FILE="/var/tmp/last_${BRANCH}_k8s_patch_release"
-  # STABLE_RELEASED_FILE keeps the last release we did to candidate.
-  export STABLE_RELEASE_FILE="/var/tmp/last_${BRANCH}_k8s_patch_release.to_stable"
 
   # Work only on the available branches (eg 2.0 might not be there yet)
   if [[ $KUBE_VERSION != *"Error"* ]]
@@ -112,13 +145,8 @@ do
     if [ "$trigger" == 'yes' ]
     then
       build_promote
-      echo "$KUBE_VERSION" > $LAST_RELEASE_FILE
     fi
 
     promote_stable
-    if [ "$stable_promotion" == 'yes' ]
-    then
-      echo "$KUBE_VERSION" > $STABLE_RELEASE_FILE
-    fi
   fi
 done


### PR DESCRIPTION
 * Changed script to not write status to disk. This will allow it to run on any machine. This means we ask the snap store for version and timestamps.

 * Updated script to fallback to beta and then alpha versions so we can test betas and alphas before they go stable to get a head start on releases.

 * Also added new kubernetes tracks.

Would be nice to remove some of these greps. Maybe it would be good to write this in python?