### PR TITLE
support building/releasing snaps with a -suffix; make sure we're the right user

### DIFF
--- a/snaps/build-and-release-aws-eks-snaps.sh
+++ b/snaps/build-and-release-aws-eks-snaps.sh
@@ -7,6 +7,9 @@ set -eux
 EKS_RELEASE="${EKS_RELEASE:-edge}"
 KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
 KUBE_ARCH="amd64"
+
+# This suffix is used by the snap build script when we run make targets:
+#  https://github.com/juju-solutions/release/blob/rye/snaps/snap/build-scripts/build
 export SNAP_SUFFIX="eks"
 
 source utilities.sh

--- a/snaps/build-and-release-aws-eks-snaps.sh
+++ b/snaps/build-and-release-aws-eks-snaps.sh
@@ -4,13 +4,12 @@
 # This script will build and release snaps for AWS EKS.
 set -eux
 
-EKS_RELEASE="${EKS_RELEASE:-edge/eks.0}"
+EKS_RELEASE="${EKS_RELEASE:-edge}"
 KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
 KUBE_ARCH="amd64"
+export SNAP_SUFFIX="eks"
 
 source utilities.sh
-MAIN_VERSION=$(get_major_minor $KUBE_VERSION)
-
 source utils/retry.sh
 
 rm -rf ./release
@@ -20,8 +19,13 @@ git clone https://github.com/juju-solutions/release.git --branch rye/snaps --dep
     targets="kubectl kubelet kube-proxy kubernetes-test"
 )
 
-for app in kubectl kubelet kube-proxy kubernetes-test; do
+# Ensure we are the correct user
+if ! $(snapcraft whoami | grep -q canonical-cloud-snaps); then
+  echo "Cannot release CPC snaps (wrong user)"
+  exit 1
+fi
+for app in kubectl-eks kubelet-eks kube-proxy-eks kubernetes-test-eks; do
   for arch in $KUBE_ARCH; do
-    retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${arch}.snap --release ${MAIN_VERSION}/${EKS_RELEASE}
+    retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${arch}.snap --release ${EKS_RELEASE}
   done
 done

--- a/snaps/build-and-release-aws-eks-snaps.sh
+++ b/snaps/build-and-release-aws-eks-snaps.sh
@@ -19,7 +19,7 @@ git clone https://github.com/juju-solutions/release.git --branch rye/snaps --dep
     targets="kubectl kubelet kube-proxy kubernetes-test"
 )
 
-# Ensure we are the correct user
+# Ensure we are the correct user (jenkins job does a 'snapcraft login $token')
 if ! $(snapcraft whoami | grep -q canonical-cloud-snaps); then
   echo "Cannot release CPC snaps (wrong user)"
   exit 1

--- a/snaps/promote-snaps.sh
+++ b/snaps/promote-snaps.sh
@@ -18,22 +18,13 @@ echo ARCH="$ARCH"
 
 . utils/retry.sh
 
-# Set a flag if we're building the EKS variants
+# Ensure we are the correct user (jenkins job does a 'snapcraft login $token')
 if [[ "${SNAPS}" =~ "-eks" ]]; then
-  build_eks=true
-fi
-
-# Ensure we are the correct user
-if [ "$build_eks" = true ]; then
-  cp -a /var/lib/jenkins/.config/snapcraft/snapcraft-cpc.cfg \
-        /var/lib/jenkins/.config/snapcraft/snapcraft.cfg
   if ! $(snapcraft whoami | grep -q canonical-cloud-snaps); then
     echo "Cannot release CPC snaps (wrong user)"
     exit 1
   fi
 else
-  cp -a /var/lib/jenkins/.config/snapcraft/snapcraft-cdkbot.cfg \
-        /var/lib/jenkins/.config/snapcraft/snapcraft.cfg
   if ! $(snapcraft whoami | grep -q cdkbot); then
     echo "Cannot release cdkbot snaps (wrong user)"
     exit 1
@@ -70,9 +61,3 @@ for snap in $SNAPS; do
     done
   done
 done
-
-# Set credentials back to our default user
-if [ "$build_eks" = true ]; then
-  cp -a /var/lib/jenkins/.config/snapcraft/snapcraft-cdkbot.cfg \
-        /var/lib/jenkins/.config/snapcraft/snapcraft.cfg
-fi

--- a/snaps/promote-snaps.sh
+++ b/snaps/promote-snaps.sh
@@ -47,7 +47,7 @@ create_git_branch_if_not_exists () {
       echo "GH_USER or GH_TOKEN not set, not creating branch for stable promotion release-${1}."
     else
       echo "Creating new branch for release-${1}."
-      create_branch "juju-solutions" "cdk-addons" ${GH_USER} ${GH_TOKEN  } $1
+      create_branch "juju-solutions" "cdk-addons" ${GH_USER} ${GH_TOKEN} $1
     fi
   fi
 }


### PR DESCRIPTION
Build EKS snaps just like our others, but tack on an -eks suffix.  SNAP_SUFFIX is now supported by the build scripts (https://github.com/juju-solutions/release/pull/21), so adjust the eks job to use it.

Also double check that we are the right user before doing snapcraft release (eks snaps are managed by the cpc team).