### PR TITLE
Move github branch creation to promotion of stable.

### DIFF
--- a/snaps/build-and-release-k8s-snaps.sh
+++ b/snaps/build-and-release-k8s-snaps.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
 
-# This script appart from builgin and releasing the k8s snaps will also
-# tag the cdk-addons with the release and create a branch of cdk-addons
-# upon a new k8s release. Latest k8s releases are shipped with cdk-addons
-# from the head of master, for any older releases we need to have a branch.
+# This script, apart from building and releasing the k8s snaps, will also
+# tag the cdk-addons with the release. If a branch exists for the release
+# we will build and release from that branch. If no branch exists, we will
+# build from master.
 # GH_USER and GH_TOKEN are the user and token that will touch the repo.
 
 set -eux
@@ -13,10 +13,8 @@ KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
 KUBE_ARCH="amd64"
 
 source utilities.sh
-MAIN_VERSION=$(get_major_minor $KUBE_VERSION)
-PREV_VERSION=$(get_prev_major_minor $MAIN_VERSION)
-ADDONS_BRANCH_VERSION="release-${MAIN_VERSION}"
-PREV_ADDONS_BRANCH_VERSION="release-${PREV_VERSION}"
+VERSION=$(get_major_minor $KUBE_VERSION)
+ADDONS_BRANCH_VERSION="release-${VERSION}"
 
 source utils/retry.sh
 
@@ -30,13 +28,6 @@ git clone https://github.com/juju-solutions/release.git --branch rye/snaps --dep
 )
 
 rm -rf ./cdk-addons
-# If we have no branch for the previous release just create one
-if ! git ls-remote --exit-code --heads https://github.com/juju-solutions/cdk-addons.git ${PREV_ADDONS_BRANCH_VERSION}
-then
-  echo "Creating new branch for ${PREV_ADDONS_BRANCH_VERSION}."
-  create_branch "juju-solutions" "cdk-addons" ${GH_USER} ${GH_TOKEN} ${PREV_ADDONS_BRANCH_VERSION}
-fi
-
 if git ls-remote --exit-code --heads https://github.com/juju-solutions/cdk-addons.git ${ADDONS_BRANCH_VERSION}
 then
   echo "Getting cdk-addons from ${ADDONS_BRANCH_VERSION} branch."

--- a/snaps/promote-snaps.sh
+++ b/snaps/promote-snaps.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 
 # Example usage:
-# export PROMOTE_FROM="1.6/edge"
-# export PROMOTE_TO="1.6/beta 1.6/candidate edge beta candidate"
+# export PROMOTE_FROM="1.10/edge"
+# export PROMOTE_TO="1.10/beta 1.10/candidate edge beta candidate"
 # snaps/promote-snaps.sh
 
 SNAPS="${SNAPS:-kubectl kube-apiserver kube-controller-manager kube-scheduler kubelet kube-proxy cdk-addons kubeadm kubernetes-test}"
@@ -16,6 +16,29 @@ echo ARCH="$ARCH"
 
 
 . utils/retry.sh
+
+GH_USER="${GH_USER:-}"
+GH_TOKEN="${GH_TOKEN:-}"
+
+create_git_branch_if_not_exists () {
+  if ! git ls-remote --exit-code --heads https://github.com/juju-solutions/cdk-addons.git release-${1}
+  then
+    if [ -z "$GH_USER" ] || [ -z $GH_TOKEN ]; then
+      echo "GH_USER or GH_TOKEN not set, not creating branch for stable promotion release-${1}."
+    else
+      echo "Creating new branch for release-${1}."
+      create_branch "juju-solutions" "cdk-addons" ${GH_USER} ${GH_TOKEN  } $1
+    fi
+  fi
+}
+
+# Create a branch for any stable promotion that doesn't have one.
+for branch in $PROMOTE_TO; do
+  if [[ $branch = *"/stable"* ]]; then
+    IFS='/' read -ra VER <<< "$branch"
+    create_git_branch_if_not_exists $VER
+  fi
+done
 
 for snap in $SNAPS; do
   revisions="$(snapcraft revisions $snap | grep "${ARCH}" | grep " ${PROMOTE_FROM}\*" | cut -d " " -f 1)"


### PR DESCRIPTION
The original plan of always working in master and creating branches for versions when a new version went stable falls over when you're working on multiple releases at a time. In our example, we have 1.10, 1.11, and 1.12. 1.10 is stable, 1.11 is in beta, and 1.12 is alpha. We need changes for 1.11, but don't want to break 1.10. To prevent breaking it, the decision was made to create branches for a release once the release becomes stable, so now it is in promote. Note that in our current setup, we need to merge changes
into the 1.10 branch if the changes are for both master(future) and the current(1.10) release. Also note that we can't make 1.12 unique changes until 1.11 hits stable, which is a limitation we're currently ok with here for simplicity.