### PR TITLE
Unpin libjuju taking into account the changes involved

### DIFF
--- a/integration-tests/install-deps.sh
+++ b/integration-tests/install-deps.sh
@@ -12,7 +12,7 @@ sudo snap install juju --classic
 sudo snap install conjure-up --classic
 sudo pip2 install 'git+https://github.com/juju/juju-crashdump'
 sudo pip2 install -U pyopenssl bundletester virtualenv
-sudo pip3 install -U pytest  pytest-asyncio asyncio_extras juju==0.7.2 requests pyyaml kubernetes
+sudo pip3 install -U pytest  pytest-asyncio asyncio_extras juju requests pyyaml kubernetes
 sudo pip3 install -U 'git+https://github.com/juju/amulet' # we need https://github.com/juju/amulet/pull/183
 
 # Leaving those here in case we need to build a client from bleeding edge

--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -652,10 +652,7 @@ async def validate_docker_logins(model):
 
     async def run_until_success(cmd, timeout_insec=None):
         while True:
-            timeout_innano=None
-            if timeout_insec:
-                timeout_innano = timeout_insec * 1000*1000*1000
-            action = await vessel.run(cmd, timeout=timeout_innano)
+            action = await vessel.run(cmd, timeout=timeout_insec)
             if (action.status == 'completed' and
                     'results' in action.data and
                     action.data['results']['Code'] == '0'):


### PR DESCRIPTION
We need to unpin libjuju because our tests are now failing with json parsing erro.

Fixes: https://github.com/juju-solutions/kubernetes-jenkins/issues/197