### PR TITLE
lxc slaves to use snapped charm-tools

### DIFF
--- a/integration-tests/install-deps.sh
+++ b/integration-tests/install-deps.sh
@@ -7,9 +7,10 @@ set -eux
 sudo add-apt-repository ppa:juju/stable -y
 sudo add-apt-repository ppa:tvansteenburgh/ppa -y
 sudo apt update -yq
-sudo apt install -y unzip python3-pip python-pip squashfuse snapd charm-tools
+sudo apt install -y unzip python3-pip python-pip squashfuse snapd
 sudo snap install juju --classic
 sudo snap install conjure-up --classic
+sudo snap install charm
 sudo pip2 install 'git+https://github.com/juju/juju-crashdump'
 sudo pip2 install -U pyopenssl bundletester virtualenv
 sudo pip3 install -U pytest  pytest-asyncio asyncio_extras juju requests pyyaml kubernetes


### PR DESCRIPTION
We pushed this change: https://github.com/juju-solutions/kubernetes-jenkins/commit/b07220887899c62c95b1259614bd83cf7d685e20 that uses the `--format` option of charm-tools. This option is only available in the snapped charm-tools. Currently releasing charms and bundles is failing with https://ci.kubernetes.juju.solutions/job/build-and-release-kubernetes-e2e/53/console .

 