### PR TITLE
Remove short format from charm list-resources

### DIFF
--- a/charms/promote-charm.sh
+++ b/charms/promote-charm.sh
@@ -19,7 +19,7 @@ fi
 CHARM_ID="$(charm show "$CHARM" --channel "$FROM_CHANNEL" id | grep Id: | awk '{print $2}')"
 
 declare -a RESOURCE_ARGS=()
-RESOURCES="$(charm list-resources "$CHARM_ID" --channel "$FROM_CHANNEL" --format=short | sed '/No resources found./d')"
+RESOURCES="$(charm list-resources "$CHARM_ID" --channel "$FROM_CHANNEL" | grep -v "\[Service\]" | tail -n +2 | sed -e '/^$/d' -e 's/  */-/g')"
 for resource in $RESOURCES; do
   RESOURCE_ARGS+=('-r')
   RESOURCE_ARGS+=("$resource")


### PR DESCRIPTION
This PR handles the line removed from the output of snapped charm-tools mentioned here: https://github.com/juju-solutions/kubernetes-jenkins/pull/188

However at this point we are not able to use snapped charm tools as described in https://github.com/juju-solutions/kubernetes-jenkins/pull/202 

This PR is required because at the moment the charm release process is blocked.