### PR TITLE
Make build-and-release-k8s-snaps.sh runnable on s390x

### DIFF
--- a/snaps/build-and-release-k8s-snaps.sh
+++ b/snaps/build-and-release-k8s-snaps.sh
@@ -10,7 +10,8 @@
 set -eux
 
 KUBE_VERSION="${KUBE_VERSION:-$(curl -L https://dl.k8s.io/release/stable.txt)}"
-KUBE_ARCH="amd64"
+KUBE_ARCH="$(dpkg --print-architecture)"
+SKIP_RELEASE_TAG="${SKIP_RELEASE_TAG:-false}"
 
 source utilities.sh
 VERSION=$(get_major_minor $KUBE_VERSION)
@@ -22,9 +23,7 @@ rm -rf ./release
 git clone https://github.com/juju-solutions/release.git --branch rye/snaps --depth 1
 (cd release/snap
   make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH="$KUBE_ARCH" \
-    targets="kubeadm kube-apiserver kubectl kubelet kube-proxy kube-scheduler"
-  make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH="amd64" \
-    targets="kube-controller-manager kubernetes-test"
+    targets="kubeadm kube-apiserver kubectl kubelet kube-proxy kube-scheduler kube-controller-manager kubernetes-test"
 )
 
 rm -rf ./cdk-addons
@@ -32,26 +31,20 @@ if git ls-remote --exit-code --heads https://github.com/juju-solutions/cdk-addon
 then
   echo "Getting cdk-addons from ${ADDONS_BRANCH_VERSION} branch."
   git clone https://github.com/juju-solutions/cdk-addons.git --branch ${ADDONS_BRANCH_VERSION} --depth 1
-  tag_release  "juju-solutions" "cdk-addons" ${ADDONS_BRANCH_VERSION} ${GH_USER} ${GH_TOKEN} ${KUBE_VERSION}
+  if [ "$SKIP_RELEASE_TAG" != "true" ]; then
+    tag_release  "juju-solutions" "cdk-addons" ${ADDONS_BRANCH_VERSION} ${GH_USER} ${GH_TOKEN} ${KUBE_VERSION}
+  fi
 else
   echo "Branch for ${ADDONS_BRANCH_VERSION} does not exist. Getting cdk-addons from master head."
   git clone https://github.com/juju-solutions/cdk-addons.git --depth 1
-  tag_release  "juju-solutions" "cdk-addons" "master" ${GH_USER} ${GH_TOKEN} ${KUBE_VERSION}
+  if [ "$SKIP_RELEASE_TAG" != "true" ]; then
+    tag_release  "juju-solutions" "cdk-addons" "master" ${GH_USER} ${GH_TOKEN} ${KUBE_VERSION}
+  fi
 fi
-for arch in $KUBE_ARCH; do
-  (cd cdk-addons && make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH=${arch})
+(cd cdk-addons && make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH=${KUBE_ARCH})
+
+for app in kubeadm kube-apiserver kubectl kubelet kube-proxy kube-scheduler kube-controller-manager kubernetes-test; do
+  retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${KUBE_ARCH}.snap --release ${VERSION}/edge
 done
 
-for app in kubeadm kube-apiserver kubectl kubelet kube-proxy kube-scheduler; do
-  for arch in $KUBE_ARCH; do
-    retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_${arch}.snap --release ${MAIN_VERSION}/edge
-  done
-done
-
-for app in kube-controller-manager kubernetes-test; do
-  retry snapcraft push release/snap/build/${app}_${KUBE_VERSION:1}_amd64.snap --release ${MAIN_VERSION}/edge
-done
-
-for arch in $KUBE_ARCH; do
-  retry snapcraft push cdk-addons/cdk-addons_${KUBE_VERSION:1}_${arch}.snap --release ${MAIN_VERSION}/edge
-done
+retry snapcraft push cdk-addons/cdk-addons_${KUBE_VERSION:1}_${KUBE_ARCH}.snap --release ${VERSION}/edge


### PR DESCRIPTION
@ktsakalozos I made some changes to make it possible to run this script on s390x. Do you think this is worth merging in?

1. Use `dpkg --print-architecture` instead of hardcoding to amd64
2. Remove the special cases that hardcode kube-controller-manager and kubernetes-test to amd64. Those special cases are very outdated and no longer relevant.
3. Add `SKIP_RELEASE_TAG` to make it possible to run this without GH_USER and GH_TOKEN. There is probably a better way to handle this but the tagging doesn't currently account for multiple architectures. I took the easy way out for now.
4. Remove `MAIN_VERSION` (which is currently passed in from Jenkins) and just use `VERSION` instead since they seem to be identical. I can't think of a case where they'd ever be different.

Of course, running this on our s390x machine with these changes is still a bit unwieldy:
```
HTTP_PROXY=http://squid.internal:3128 HTTPS_PROXY=https://squid.internal:3128 NO_PROXY=snapcraft.io,ubuntu.com SKIP_RELEASE_TAG=true KUBE_VERSION=v1.10.5 ./snaps/build-and-release-k8s-snaps.sh
```

Cc @kwmonroe since you've got arm64 on your plate