### PR TITLE
Fixes for running our tests on lxd

### DIFF
--- a/integration-tests/utils.py
+++ b/integration-tests/utils.py
@@ -261,6 +261,14 @@ async def juju_deploy(model, namespace, bundle, channel='stable', snap_channel=N
                 yaml.dump(data, f)
         await model.deploy(bundle_dir)
     await wait_for_ready(model)
+    # In localhost we need proxy-extra-args="proxy-mode=userspace"
+    if is_localhost():
+        workers = model.applications['kubernetes-worker']
+        new_config={
+            'proxy-extra-args': 'proxy-mode=userspace'
+        }
+        await workers.set_config(new_config)
+        await wait_for_ready(model)
 
 
 def asyncify(f):

--- a/integration-tests/utils.py
+++ b/integration-tests/utils.py
@@ -260,7 +260,6 @@ async def juju_deploy(model, namespace, bundle, channel='stable', snap_channel=N
             with open(data_path, 'w') as f:
                 yaml.dump(data, f)
         await model.deploy(bundle_dir)
-    await wait_for_ready(model)
     # In localhost we need proxy-extra-args="proxy-mode=userspace"
     if is_localhost():
         workers = model.applications['kubernetes-worker']
@@ -268,7 +267,7 @@ async def juju_deploy(model, namespace, bundle, channel='stable', snap_channel=N
             'proxy-extra-args': 'proxy-mode=userspace'
         }
         await workers.set_config(new_config)
-        await wait_for_ready(model)
+    await wait_for_ready(model)
 
 
 def asyncify(f):

--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -477,7 +477,7 @@ async def validate_extra_args(model):
     async def get_service_args(app, service):
         results = []
         for unit in app.units:
-            action = await unit.run('pgrep -af ' + service)
+            action = await unit.run('pgrep -a ' + service)
             assert action.status == 'completed'
             raw_output = action.data['results']['Stdout']
             arg_string = raw_output.partition(' ')[2].partition(' ')[2]

--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -542,7 +542,7 @@ async def validate_extra_args(model):
                 'watch-cache',
                 'enable-swagger-ui=false'
             },
-            'kube-controller-manager': {
+            'kube-controller': {
                 'v 3',
                 'profiling',
                 'contention-profiling=false'


### PR DESCRIPTION
A couple of fixes for running our tests on lxd.

- we need a special proxy setting.
- removed the f from `pgrep -af` because it was picking up processes that were not the services we were interested in. 