### PR TITLE
Fix errors during audit test

### DIFF
--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -888,7 +888,7 @@ async def assert_hook_occurs_on_all_units(app, hook):
 
     for unit in app.units:
         @unit.on_change
-        def on_change(delta, old, new, model):
+        async def on_change(delta, old, new, model):
             unit_id = new.entity_id
             if new.agent_status_message == 'running ' + hook + ' hook':
                 started_units.add(unit_id)


### PR DESCRIPTION
Totally untested, we should wait until a good time to land this, but I think this should fix the error spew we get during the audit tests:

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/usr/local/lib/python3.5/dist-packages/juju/model.py", line 58, in __call__
    await self.callable_(delta, old, new, model)
TypeError: object NoneType can't be used in 'await' expression
```

It is trying to await the callable `on_change`, but since our callable is not async, calling it returns `None` instead of a coroutine.