### PR TITLE
Fix arg format in validate_extra_args

### DIFF
--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -538,17 +538,17 @@ async def validate_extra_args(model):
         },
         expected_args={
             'kube-apiserver': {
-                'min-request-timeout 314',
+                'min-request-timeout=314',
                 'watch-cache',
                 'enable-swagger-ui=false'
             },
             'kube-controller': {
-                'v 3',
+                'v=3',
                 'profiling',
                 'contention-profiling=false'
             },
             'kube-scheduler': {
-                'v 3',
+                'v=3',
                 'profiling',
                 'contention-profiling=false'
             }
@@ -571,12 +571,12 @@ async def validate_extra_args(model):
         },
         expected_args={
             'kubelet': {
-                'v 1',
+                'v=1',
                 'enable-server',
                 'alsologtostderr=false'
             },
             'kube-proxy': {
-                'v 1',
+                'v=1',
                 'profiling',
                 'alsologtostderr=false'
             }


### PR DESCRIPTION
Fix for `TimeoutError: Timed out after 600.000000 seconds` error that is occurring in validate_extra_args on CI.

I broke this test with https://github.com/juju-solutions/release/pull/26. This PR fixes the test.