### PR TITLE
Inject proxies and skip tests based on architecture

### DIFF
--- a/integration-tests/utils.py
+++ b/integration-tests/utils.py
@@ -253,34 +253,38 @@ async def juju_deploy(model, namespace, bundle, channel='stable', snap_channel=N
         data_path = os.path.join(bundle_dir, 'bundle.yaml')
         with open(data_path) as f:
             data = yaml.load(f)
-            if os.getenv('http_proxy') and os.getenv('https_proxy'):
-                # Lets inject proxy settings
-                http_proxy = os.environ.get('http_proxy')
-                https_proxy = os.environ.get('https_proxy')
-                snap_proxy = https_proxy
-                options = data['services']['kubernetes-worker'].setdefault('options', {})
-                options['http_proxy'] = http_proxy
-                options['https_proxy'] = https_proxy
-                # In localhost we need proxy-extra-args="proxy-mode=userspace"
-                if await is_localhost():
-                    options['proxy-extra-args'] = 'proxy-mode=userspace'
-                for app in ['kubernetes-master', 'kubernetes-worker', 'etcd']:
-                    options = data['services'][app].setdefault('options', {})
-                    options['snap_proxy'] = snap_proxy
-            if arch() == 's390x':
-                options = data['services']['etcd'].setdefault('options', {})
-                options['channel'] = "2.3/stable"
-                options = data['services']['kubernetes-master'].setdefault('options', {})
-                options['enable-dashboard-addons'] = "false"
-                options['enable-metrics'] = "false"
-            if snap_channel:
-                for app in ['kubernetes-master', 'kubernetes-worker']:
-                    options = data['services'][app].setdefault('options', {})
-                    options['channel'] = snap_channel
+            await patch_bundle(data, snap_channel)
             with open(data_path, 'w') as f:
                 yaml.dump(data, f)
         await model.deploy(bundle_dir)
     await wait_for_ready(model)
+
+
+async def patch_bundle(bundle, snap_channel):
+    ''' Patch the bundle with snap, procy and arch specific properties. '''
+    if os.getenv('http_proxy') and os.getenv('https_proxy'):
+        # Lets inject proxy settings
+        http_proxy = os.environ.get('http_proxy')
+        https_proxy = os.environ.get('https_proxy')
+        snap_proxy = https_proxy
+        options = bundle['services']['kubernetes-worker'].setdefault('options', {})
+        options['http_proxy'] = http_proxy
+        options['https_proxy'] = https_proxy
+        if await is_localhost():
+            options['proxy-extra-args'] = 'proxy-mode=userspace'
+        for app in ['kubernetes-master', 'kubernetes-worker', 'etcd']:
+            options = bundle['services'][app].setdefault('options', {})
+            options['snap_proxy'] = snap_proxy
+    if arch() == 's390x':
+        options = bundle['services']['etcd'].setdefault('options', {})
+        options['channel'] = "2.3/stable"
+        options = bundle['services']['kubernetes-master'].setdefault('options', {})
+        options['enable-dashboard-addons'] = "false"
+        options['enable-metrics'] = "false"
+    if snap_channel:
+        for app in ['kubernetes-master', 'kubernetes-worker']:
+            options = bundle['services'][app].setdefault('options', {})
+            options['channel'] = snap_channel
 
 
 def asyncify(f):
@@ -361,31 +365,11 @@ async def run_bundletester(namespace, log_dir, channel='stable', snap_channel=No
         bundle_dir = os.path.join(log_dir, bundle)
         cmd = ['charm', 'pull', url, '--channel', channel, bundle_dir]
         await asyncify(subprocess.check_call)(cmd)
-
         # update bundle config
         data_path = os.path.join(bundle_dir, 'bundle.yaml')
         with open(data_path) as f:
             data = yaml.load(f)
-            if os.getenv('http_proxy') and os.getenv('https_proxy'):
-                # Lets inject proxy settings
-                http_proxy = os.environ.get('http_proxy')
-                https_proxy = os.environ.get('https_proxy')
-                snap_proxy = https_proxy
-                options = data['services']['kubernetes-worker'].setdefault('options', {})
-                options['http_proxy'] = http_proxy
-                options['https_proxy'] = https_proxy
-                if await is_localhost():
-                    options['proxy-extra-args'] = 'proxy-mode=userspace'
-                for app in ['kubernetes-master', 'kubernetes-worker', 'etcd']:
-                    options = data['services'][app].setdefault('options', {})
-                    options['snap_proxy'] = snap_proxy
-            if arch() == 's390x':
-                options = data['services']['etcd'].setdefault('options', {})
-                options['channel'] = "2.3/stable"
-            if snap_channel:
-                for app in ['kubernetes-master', 'kubernetes-worker']:
-                    options = data['services'][app].setdefault('options', {})
-                    options['channel'] = snap_channel
+            await patch_bundle(data, snap_channel)
             data['services']['kubernetes-worker'].setdefault('options', {})['labels'] = 'mylabel=thebest'
             yaml.Dumper.ignore_aliases = lambda *args: True
             with open(data_path, 'w') as f:

--- a/integration-tests/utils.py
+++ b/integration-tests/utils.py
@@ -250,23 +250,33 @@ async def juju_deploy(model, namespace, bundle, channel='stable', snap_channel=N
         bundle_dir = os.path.join(temp_dir, 'bundle')
         cmd = ['charm', 'pull', '--channel', channel, url, bundle_dir]
         await asyncify(subprocess.check_call)(cmd)
-        if snap_channel:
-            data_path = os.path.join(bundle_dir, 'bundle.yaml')
-            with open(data_path) as f:
-                data = yaml.load(f)
-            for app in ['kubernetes-master', 'kubernetes-worker']:
-                options = data['services'][app].setdefault('options', {})
-                options['channel'] = snap_channel
+        data_path = os.path.join(bundle_dir, 'bundle.yaml')
+        with open(data_path) as f:
+            data = yaml.load(f)
+            if os.getenv('http_proxy') and os.getenv('https_proxy'):
+                # Lets inject proxy settings
+                http_proxy = os.environ.get('http_proxy')
+                https_proxy = os.environ.get('https_proxy')
+                snap_proxy = https_proxy
+                options = data['services']['kubernetes-worker'].setdefault('options', {})
+                options['http_proxy'] = http_proxy
+                options['https_proxy'] = https_proxy
+                # In localhost we need proxy-extra-args="proxy-mode=userspace"
+                if await is_localhost():
+                    options['proxy-extra-args'] = 'proxy-mode=userspace'
+                for app in ['kubernetes-master', 'kubernetes-worker', 'etcd']:
+                    options = data['services'][app].setdefault('options', {})
+                    options['snap_proxy'] = snap_proxy
+            if arch() == 's390x':
+                options = data['services']['etcd'].setdefault('options', {})
+                options['channel'] = "2.3/stable"
+            if snap_channel:
+                for app in ['kubernetes-master', 'kubernetes-worker']:
+                    options = data['services'][app].setdefault('options', {})
+                    options['channel'] = snap_channel
             with open(data_path, 'w') as f:
                 yaml.dump(data, f)
         await model.deploy(bundle_dir)
-    # In localhost we need proxy-extra-args="proxy-mode=userspace"
-    if await is_localhost():
-        workers = model.applications['kubernetes-worker']
-        new_config={
-            'proxy-extra-args': 'proxy-mode=userspace'
-        }
-        await workers.set_config(new_config)
     await wait_for_ready(model)
 
 
@@ -351,16 +361,32 @@ async def run_bundletester(namespace, log_dir, channel='stable', snap_channel=No
 
         # update bundle config
         data_path = os.path.join(bundle_dir, 'bundle.yaml')
-        with open(data_path, 'r') as f:
+        with open(data_path) as f:
             data = yaml.load(f)
-        if snap_channel:
-            for app in ['kubernetes-master', 'kubernetes-worker']:
-                options = data['services'][app].setdefault('options', {})
-                options['channel'] = snap_channel
-        data['services']['kubernetes-worker'].setdefault('options', {})['labels'] = 'mylabel=thebest'
-        yaml.Dumper.ignore_aliases = lambda *args: True
-        with open(data_path, 'w') as f:
-            yaml.dump(data, f, default_flow_style=False)
+            if os.getenv('http_proxy') and os.getenv('https_proxy'):
+                # Lets inject proxy settings
+                http_proxy = os.environ.get('http_proxy')
+                https_proxy = os.environ.get('https_proxy')
+                snap_proxy = https_proxy
+                options = data['services']['kubernetes-worker'].setdefault('options', {})
+                options['http_proxy'] = http_proxy
+                options['https_proxy'] = https_proxy
+                if await is_localhost():
+                    options['proxy-extra-args'] = 'proxy-mode=userspace'
+                for app in ['kubernetes-master', 'kubernetes-worker', 'etcd']:
+                    options = data['services'][app].setdefault('options', {})
+                    options['snap_proxy'] = snap_proxy
+            if arch() == 's390x':
+                options = data['services']['etcd'].setdefault('options', {})
+                options['channel'] = "2.3/stable"
+            if snap_channel:
+                for app in ['kubernetes-master', 'kubernetes-worker']:
+                    options = data['services'][app].setdefault('options', {})
+                    options['channel'] = snap_channel
+            data['services']['kubernetes-worker'].setdefault('options', {})['labels'] = 'mylabel=thebest'
+            yaml.Dumper.ignore_aliases = lambda *args: True
+            with open(data_path, 'w') as f:
+                yaml.dump(data, f, default_flow_style=False)
 
         # run bundletester
         output_file = os.path.join(log_dir, 'bundletester.xml')
@@ -429,3 +455,10 @@ async def retry_async_with_timeout(func, args, timeout_insec=600,
         await asyncio.sleep(retry_interval_insec)
     else:
         raise TimeoutError(timeout_msg)
+
+
+def arch():
+    '''Return the package architecture as a string.'''
+    architecture = check_output(['dpkg', '--print-architecture']).rstrip()
+    architecture = architecture.decode('utf-8')
+    return architecture

--- a/integration-tests/utils.py
+++ b/integration-tests/utils.py
@@ -270,6 +270,9 @@ async def juju_deploy(model, namespace, bundle, channel='stable', snap_channel=N
             if arch() == 's390x':
                 options = data['services']['etcd'].setdefault('options', {})
                 options['channel'] = "2.3/stable"
+                options = data['services']['kubernetes-master'].setdefault('options', {})
+                options['enable-dashboard-addons'] = "false"
+                options['enable-metrics'] = "false"
             if snap_channel:
                 for app in ['kubernetes-master', 'kubernetes-worker']:
                     options = data['services'][app].setdefault('options', {})

--- a/integration-tests/validation.py
+++ b/integration-tests/validation.py
@@ -26,16 +26,16 @@ from utils import (
 
 @log_calls_async
 async def validate_all(model, log_dir):
-    arch = arch()
+    cpu_arch = await asyncify(arch)()
     validate_status_messages(model)
     await validate_snap_versions(model)
     await validate_gpu_support(model)
-    if arch != 's390x':
+    if cpu_arch != 's390x':
         await validate_dashboard(model, log_dir)
     await validate_kubelet_anonymous_auth_disabled(model)
     await validate_rbac_flag(model)
     await validate_rbac(model)
-    if arch not in ['s390x', 'arm64']:
+    if cpu_arch not in ['s390x', 'arm64']:
         await validate_microbot(model)
         await validate_e2e_tests(model, log_dir)
         await validate_docker_logins(model)


### PR DESCRIPTION
We should now be able to `pytest -s --no-print-logs ./integration-tests/test_live_model.py` as soon as we bootstrap a controller.