### PR TITLE
Add microk8s scripts

### DIFF
--- a/maintenance/provision-lxc-node.sh
+++ b/maintenance/provision-lxc-node.sh
@@ -14,6 +14,9 @@ done
 PUSH integration-tests/install-deps.sh /root/
 RUN /root/install-deps.sh
 
+PUSH microk8s/install-deps.sh /root/
+RUN /root/install-deps.sh
+
 RUN mkdir -p /root/.local/share/juju
 
 PUSH ~/.local/share/juju/accounts.yaml /root/.local/share/juju/

--- a/microk8s/build-and-release-on-new-upstream-release.py
+++ b/microk8s/build-and-release-on-new-upstream-release.py
@@ -11,6 +11,7 @@ tracks = ["latest", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15"]
 
 
 def upstream_release(release):
+    """Return the latest stable k8s in the release series"""
     if release == "latest":
         release_url = "https://dl.k8s.io/release/stable.txt"
     else:
@@ -24,6 +25,7 @@ def upstream_release(release):
 
 
 def snapped_release(track):
+    """ Return the version of the microk8s snap in the edge channel and the track provided"""
     snap_details = public_api.get_snap_details('microk8s', 'edge')
     tracks = snap_details['channel_maps_list']
     versions = [c['version'] for t in tracks if t['track'] == track
@@ -33,6 +35,8 @@ def snapped_release(track):
 
 
 def trigger_lp_builders(track):
+    """Trigger the LP builder of the track provided. This method will
+    login using the cached credentials or prompt you for authorization."""
     if track == "latest":
         snap_name = "microk8s"
     else:

--- a/microk8s/build-and-release-on-new-upstream-release.py
+++ b/microk8s/build-and-release-on-new-upstream-release.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+
+import requests
+import configbag
+import canonicalwebteam.snapstoreapi.public_api as public_api
+from launchpadlib.launchpad import Launchpad
+from lazr.restfulclient.errors import HTTPError
+
+
+tracks = ["latest", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15"]
+
+
+def upstream_release(release):
+    if release == "latest":
+        release_url = "https://dl.k8s.io/release/stable.txt"
+    else:
+        release_url = "https://dl.k8s.io/release/stable-{}.txt".format(release)
+
+    r = requests.get(release_url)
+    if r.status_code == 200:
+        return r.content.decode().strip()
+    else:
+        None
+
+
+def snapped_release(track):
+    snap_details = public_api.get_snap_details('microk8s', 'edge')
+    tracks = snap_details['channel_maps_list']
+    versions = [c['version'] for t in tracks if t['track'] == track
+                for c in t['map'] if c['channel'] == 'edge']
+    version = versions[0] if versions else None
+    return version
+
+
+def trigger_lp_builders(track):
+    if track == "latest":
+        snap_name = "microk8s"
+    else:
+        snap_name = "microk8s-{}".format(track)
+
+    # log in
+    launchpad = Launchpad.login_with('Launchpad Snap Build Trigger',
+                                     'production', configbag.cachedir,
+                                     credentials_file=configbag.creds,
+                                     version='devel')
+
+    # get launchpad team data and ppa
+    snappydev = launchpad.people[configbag.people_name]
+
+    try:
+        # get snap
+        microk8s = launchpad.snaps.getByName(name=snap_name,
+                                               owner=snappydev)
+    except HTTPError as e:
+        print("Cannot trigger build for track {}. ({})".format(track, e.response))
+        return None
+
+    # trigger build
+    ubuntu = launchpad.distributions["ubuntu"]
+    request = microk8s.requestBuilds(archive=ubuntu.main_archive,
+                                      pocket='Updates')
+    return request
+
+
+if __name__ == '__main__':
+    print("Running a build and release of microk8s")
+    for track in tracks:
+        print("Looking at track {}".format(track))
+        upstream = upstream_release(track)
+        if not upstream:
+            continue
+        snapped = snapped_release(track)
+        print("Upstream has {} and snapped version is at {}".format(upstream, snapped))
+        if upstream != snapped:
+            print("Triggering LP builders")
+            request = trigger_lp_builders(track)
+            if request:
+                print("microk8s is building under: {}".format(request))

--- a/microk8s/configbag.py
+++ b/microk8s/configbag.py
@@ -1,0 +1,11 @@
+import os
+
+# basic paths
+home = os.getenv("HOME")
+workdir = home + "/snap-builds"
+snap_name = "microk8s"
+# basic data
+people_name = "microk8s-dev"
+# we need to store credentials once for cronned builds
+cachedir = workdir + "/cache"
+creds = workdir + "/credentials"

--- a/microk8s/create-secret.py
+++ b/microk8s/create-secret.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+from launchpadlib.launchpad import Launchpad
+import configbag
+
+def reach_lp_builders():
+    # log in
+    launchpad = Launchpad.login_with('Launchpad Snap Build Trigger',
+                                     'production', configbag.cachedir,
+                                     credentials_file=configbag.creds,
+                                     version='devel')
+
+    # get launchpad team data and ppa
+    snappydev = launchpad.people[configbag.people_name]
+
+    launchpad.snaps.getByName(name=configbag.snap_name, owner=snappydev)
+
+
+if __name__ == '__main__':
+    print("Trying to reach microk8s builders")
+    reach_lp_builders()

--- a/microk8s/create-secret.py
+++ b/microk8s/create-secret.py
@@ -3,6 +3,8 @@ from launchpadlib.launchpad import Launchpad
 import configbag
 
 def reach_lp_builders():
+    """Try to login to LP and reach the latest microk8s snap. It will prompt you for
+    authorisation if no credentials file is found."""
     # log in
     launchpad = Launchpad.login_with('Launchpad Snap Build Trigger',
                                      'production', configbag.cachedir,

--- a/microk8s/install-deps.sh
+++ b/microk8s/install-deps.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# known good version 1.10.6
+sudo pip3 install -U launchpadlib
+# Known good version 0.4.4
+sudo pip3 install -U  canonicalwebteam.snapstoreapi


### PR DESCRIPTION
With this PR we add a Jenkins job that would periodically run and trigger the LP builders for microk8s. This way microk8s snaps will stay up-to-date.

One secret needs to be available on Jenkins and two python libs on every slave so we can talk to the snapstore and LP.

This work needs more automation (branch and builders creation) but this is the first step where source branches and builders are created manually. 