### PR TITLE
Fix "Pull from upstream kubernetes" job not keeping up with fork

### DIFF
--- a/maintenance/update-juju-solutions-fork.sh
+++ b/maintenance/update-juju-solutions-fork.sh
@@ -6,9 +6,9 @@ set -eu
 # In the rare case that the merge fails, we can manually merge. The Jenkins job will notify via IRC when it fails.
 
 git checkout master
+git pull origin master
 if ! git remote|grep upstream; then
   git remote add upstream https://github.com/kubernetes/kubernetes.git
 fi
 git pull upstream master
-git merge upstream/master
 git push https://${CDKBOT_LOGIN}@github.com/juju-solutions/kubernetes master


### PR DESCRIPTION
This should fix the following CI failure:
```
+ ./kubernetes-jenkins/maintenance/update-juju-solutions-fork.sh
Previous HEAD position was 3e19d95... new snapd_refresh config to control snapd refresh frequency (#141)
Switched to branch 'master'
Your branch and 'origin/master' have diverged,
and have 1 and 1 different commit each, respectively.
  (use "git pull" to merge the remote branch into yours)
upstream
From https://github.com/kubernetes/kubernetes
 * branch            master     -> FETCH_HEAD
Already up-to-date.
Already up-to-date.
To https://****@github.com/juju-solutions/kubernetes
 ! [rejected]        master -> master (non-fast-forward)
error: failed to push some refs to 'https://****@github.com/juju-solutions/kubernetes'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Build step 'Execute shell' marked build as failure
```

The problem is that the build is checking out a local `master` branch that does not have the latest code from `origin` (aka `juju-solutions`). We need to merge before we can push.

We can fix it easily enough by pulling from `origin` - which will do a merge - before we try to push back to it.