### PR TITLE
k8s cncf conformance pipeline

### DIFF
--- a/jobs/.gitignore
+++ b/jobs/.gitignore
@@ -1,0 +1,1 @@
+jjb-conf.ini

--- a/jobs/Pipfile
+++ b/jobs/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+jenkins-job-builder = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/jobs/Pipfile.lock
+++ b/jobs/Pipfile.lock
@@ -1,0 +1,143 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "0061fad82522c0aaad5bda4dce2f854a23831e316f3127710535c122defd4670"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+            ],
+            "version": "==2018.4.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "fasteners": {
+            "hashes": [
+                "sha256:427c76773fe036ddfa41e57d89086ea03111bbac57c55fc55f3006d027107e18",
+                "sha256:564a115ff9698767df401efca29620cbb1a1c2146b7095ebd304b79cc5807a7c"
+            ],
+            "version": "==0.14.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "jenkins-job-builder": {
+            "hashes": [
+                "sha256:38d928e3959002a3f9e96eb3a257edc4a52f92a8358455fdb57265812f19bbdc",
+                "sha256:c309bc626a02d25c7c280ca75623d55c7982d57c1a7cc368ad1a8ca091ac1a5f"
+            ],
+            "index": "pypi",
+            "version": "==2.2.1"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
+                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+            ],
+            "version": "==2.10"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+            ],
+            "version": "==1.0"
+        },
+        "monotonic": {
+            "hashes": [
+                "sha256:23953d55076df038541e648a53676fb24980f7a1be290cdda21300b3bc21dfb0",
+                "sha256:552a91f381532e33cbd07c6a2655a21908088962bb8fa7239ecbcc6ad1140cc7"
+            ],
+            "version": "==1.5"
+        },
+        "multi-key-dict": {
+            "hashes": [
+                "sha256:3a1e1fc705a30a7de1a153ec2992b3ca3655ccd9225d2e427fe6525c8f160d6d",
+                "sha256:deebdec17aa30a1c432cb3f437e81f8621e1c0542a0c0617a74f71e232e9939e"
+            ],
+            "version": "==2.0.3"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:1b8be50d938c9bb75d0eaf7eda111eec1bf6dc88a62a6412e33bf077457e0f45",
+                "sha256:b486975c0cafb6beeb50ca0e17ba047647f229087bd74e37f4a7e2cac17d2caa"
+            ],
+            "version": "==4.2.0"
+        },
+        "python-jenkins": {
+            "hashes": [
+                "sha256:38224194d5a5055489f547b9c994bd8f6f9f6c2bbe69255255a20344b2bcca4c",
+                "sha256:e27d334ce8db8c9f9e9d1b48ef015e5fd6be3e28019f8bf85e814bff103cc782"
+            ],
+            "version": "==1.1.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+            ],
+            "version": "==3.13"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+            ],
+            "version": "==2.19.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "stevedore": {
+            "hashes": [
+                "sha256:1e153545aca7a6a49d8337acca4f41c212fbfa60bf864ecd056df0cafb9627e8",
+                "sha256:c7eac1c0d95824c88b655273da5c17cdde6482b2739f47c30bf851dcc9d3c2c0"
+            ],
+            "version": "==1.29.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+            ],
+            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.2.*' and python_version < '4' and python_version != '3.3.*'",
+            "version": "==1.23"
+        }
+    },
+    "develop": {}
+}

--- a/jobs/ci-master.yaml
+++ b/jobs/ci-master.yaml
@@ -1,0 +1,8 @@
+# K8s Jenkin GIT repos
+- scm:
+    name: k8s-jenkins-scm
+    scm:
+      - git:
+          url: https://github.com/juju-solutions/kubernetes-jenkins.git
+          branches:
+            - 'master'

--- a/jobs/cncf-conformance.yaml
+++ b/jobs/cncf-conformance.yaml
@@ -22,7 +22,6 @@
 
       Please see https://git.io/fNwXY for more information.
     project-type: pipeline
-    concurrent: true
     pipeline-scm:
       scm:
         - k8s-jenkins-scm

--- a/jobs/cncf-conformance.yaml
+++ b/jobs/cncf-conformance.yaml
@@ -1,0 +1,56 @@
+# CNCF Conformance Project
+# https://github.com/cncf/k8s-conformance
+#
+# Adding new versions in 'job-group', under jobs:
+# - job-group:
+#     name: '{name}-tests'
+#     jobs:
+#       - '{name}-tests-{k8sver}':
+#           k8sver: 'v1.11.x'
+#           bundle_revision: '218'
+#           cloud: ['aws', 'google']
+#       - '{name}-tests-{k8sver}':
+#           k8sver: 'v1.12.x'
+#           bundle_revision: '2xx'
+#           cloud: ['aws', 'google']
+
+
+- job-template:
+    name: '{name}-tests-{k8sver}-{cloud}'
+    description: |
+      CNCF Conformance testing for Kubernetes {k8sver} on {cloud}
+
+      Please see https://git.io/fNwXY for more information.
+    project-type: pipeline
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - k8s-jenkins-scm
+      script-path: jobs/cncf-conformance/Jenkinsfile
+    parameters:
+      - string:
+          name: bundle_revision
+          default: '{bundle_revision}'
+      - string:
+          name: sonobuoy_version
+          default: '0.11.5'
+      - string:
+          name: model
+          default: '{cloud}-k8s-conformance'
+      - string:
+          name: controller
+          default: 'jenkins-ci-{cloud}'
+
+- job-group:
+    name: '{name}-tests'
+    k8sver:
+      - 'v1.11.x':
+          bundle_revision: '218'
+    jobs:
+      - '{name}-tests-{k8sver}-{cloud}':
+          cloud: ['aws', 'google']
+
+- project:
+    name: k8s-conformance
+    jobs:
+      - '{name}-tests'

--- a/jobs/cncf-conformance/Jenkinsfile
+++ b/jobs/cncf-conformance/Jenkinsfile
@@ -1,0 +1,63 @@
+/* Handles conformance testing and result gathering for cncf https://github.com/cncf/k8s-conformance */
+pipeline {
+    agent {
+        label 'juju-client'
+    }
+    /* XXX: Global $PATH setting doesn't translate properly in pipelines
+     https://stackoverflow.com/questions/43987005/jenkins-does-not-recognize-command-sh
+     */
+    environment {
+        PATH = '/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin'
+    }
+    stages {
+        stage('Setup') {
+            steps {
+                sh "sudo snap install juju-wait --classic || true"
+                sh "sudo snap install kubectl --classic || true"
+                sh "wget -qO sonobuoy.tar.gz https://github.com/heptio/sonobuoy/releases/download/v${params.sonobuoy_version}/sonobuoy_${params.sonobuoy_version}_linux_amd64.tar.gz"
+                sh "tar xvf sonobuoy.tar.gz"
+            }
+        }
+        stage('Deploy: CDK') {
+            steps {
+                sh "juju add-model -c ${params.controller} ${params.model}"
+                sh "juju deploy -m ${params.controller}:${params.model} canonical-kubernetes-${params.bundle_revision}"
+                sh "juju-wait -e ${params.controller}:${params.model} -w"
+                sh "juju config -m ${params.controller}:${params.model} kubernetes-master allow-privileged=true"
+                sh "juju config -m ${params.controller}:${params.model} kubernetes-worker allow-privileged=true"
+            }
+        }
+        stage('Deploy: sonobuoy') {
+            steps {
+                sh "mkdir -p $HOME/.kube"
+                sh "juju scp -m ${params.controller}:${params.model} kubernetes-master/0:config $HOME/.kube/"
+                sh "export RBAC_ENABLED=\$(kubectl api-versions | grep \"rbac.authorization.k8s.io/v1beta1\" -c)"
+                sh "./sonobuoy run"
+            }
+        }
+        stage('Test') {
+            options {
+                timeout(time: 2, unit: 'HOURS')
+            }
+            steps {
+                waitUntil {
+                    script {
+                        def r = sh script:'./sonobuoy retrieve results/.', returnStatus: true
+                        return (r == 0);
+                    }
+                }
+            }
+        }
+        stage('Archive') {
+            steps {
+                archiveArtifacts artifacts: 'results/*.tar.gz'
+            }
+        }
+    }
+    post {
+        always {
+            sh "rm -rf $HOME/.kube"
+            sh "juju destroy-model -y ${params.controller}:${params.model}"
+        }
+    }
+}

--- a/jobs/readme.md
+++ b/jobs/readme.md
@@ -3,6 +3,7 @@ Running JJB
 # Prereqs
 
   - Needs `pipenv` installed
+  - Needs `pyenv` installed
   - Needs Jenkins Job Builder config (**jjb-conf.ini**):
 
 ```ini

--- a/jobs/readme.md
+++ b/jobs/readme.md
@@ -1,0 +1,41 @@
+Running JJB
+
+# Prereqs
+
+  - Needs `pipenv` installed
+  - Needs Jenkins Job Builder config (**jjb-conf.ini**):
+
+```ini
+[job_builder]
+ignore_cache=True
+keep_descriptions=False
+include_path=.:scripts:~/git/
+recursive=False
+exclude=.*:manual:./development
+allow_duplicates=False
+
+[jenkins]
+user=jenkinsuser
+password=password
+url=https://jenkinsci.com
+query_plugins_info=False
+```
+
+# Setup
+
+First setup your python environment:
+
+```
+> pipenv shell
+```
+
+# Update jobs in jenkins
+
+```
+> jenkins-jobs --conf jobs/jjb-conf.ini update jobs/
+```
+
+# References
+
+- https://jenkins.io/doc/book/pipeline/jenkinsfile/
+- http://jenkins-job-builder.readthedocs.io/en/latest/project_pipeline.html


### PR DESCRIPTION
Adds support for running automated conformance tests.

This utilizes JJB and Pipelines. This test is especially beneficial as adding variants, like new k8s versions, are just variable inputs in the yaml file and the jobs are generated as needed.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>