### PR TITLE
Use git merge when pulling from upstream

### DIFF
--- a/jobs/sync-upstream-k8s/Jenkinsfile
+++ b/jobs/sync-upstream-k8s/Jenkinsfile
@@ -29,8 +29,8 @@ pipeline {
                     sh "git config user.name 'cdkbot'"
                     sh "git remote add upstream https://github.com/kubernetes/kubernetes.git"
                     sh "git fetch upstream"
-                    sh "git rebase upstream/master"
-                    sh "git push -f https://${CDKBOT_GH}@github.com/juju-solutions/kubernetes master"
+                    sh "git merge upstream/master"
+                    sh "git push https://${CDKBOT_GH}@github.com/juju-solutions/kubernetes master"
                 }
             }
         }


### PR DESCRIPTION
@battlemidget The rebase-every-2-hours thing hasn't been working out so well for us - when we have pull requests open against juju-solutions/kubernetes master, we frequently have to rebase them, otherwise the diffs are filled with nonsense (e.g. https://github.com/juju-solutions/kubernetes/pull/156/files) and we're not able to merge them.

It seems to be getting worse as we accumulate more commits that haven't made it to upstream, too. I don't think this is sustainable.

I liked @johnsca's suggestion from IRC the other day: merge when we pull, rebase when we push, try that and see how it works.

Can we try that?