### PR TITLE
Microk8s release to beta and stable workflows

### DIFF
--- a/microk8s/configbag.py
+++ b/microk8s/configbag.py
@@ -1,5 +1,7 @@
 import os
 
+tracks = ["latest", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15"]
+
 # basic paths
 home = os.getenv("HOME")
 workdir = home + "/snap-builds"

--- a/microk8s/install-deps.sh
+++ b/microk8s/install-deps.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
 # known good version 1.10.6
-sudo pip3 install -U launchpadlib
-# Known good version 0.4.4
-sudo pip3 install -U  canonicalwebteam.snapstoreapi
+sudo pip3 install -U launchpadlib python-dateutil
+sudo snap install snapcraft --classic

--- a/microk8s/release-to-beta.py
+++ b/microk8s/release-to-beta.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3
+
+import os
+from snapstore import Microk8sSnap
+from configbag import tracks
+
+
+# Set this to 'no' if you are sure you want to release
+dry_run = os.environ.get('DRY_RUN', 'yes')
+
+# Set this to 'yes' to bypass any check such as new version present.
+always_release = os.environ.get('ALWAYS_RELEASE', 'no')
+
+# If TESTS_BRANCH is not set the tests branch will be the one matching the track
+tests_branch = os.environ.get('TESTS_BRANCH')
+if tests_branch and tests_branch.strip() == '':
+    tests_branch = None
+
+# If you do not specify TRACKS all tracks will be processes
+tracks_requested = os.environ.get('TRACKS')
+if not tracks_requested or tracks_requested.strip() == '':
+    tracks_requested = tracks
+else:
+    tracks_requested = tracks_requested.split()
+
+
+if __name__ == '__main__':
+    '''
+    Releases to beta and candidate what is under edge on the tracks provided in $TRACKS.
+    Cross distro tests should run.
+    '''
+    print("Check edge for a new release cross-distro test and release to beta and candidate.")
+    print("Dry run is set to '{}'.".format(dry_run))
+    for track in tracks_requested:
+        print("Looking at track {}".format(track))
+        edge_snap = Microk8sSnap(track, 'edge')
+        if not edge_snap.released:
+            print("Nothing released on {} edge.".format(track))
+            break
+
+        beta_snap = Microk8sSnap(track, 'beta')
+        if beta_snap.released:
+            # We already have a snap on beta. Let's see if we have to push a new release.
+            if beta_snap.version == edge_snap.version and always_release == 'no':
+                # Beta and edge are the same version. Nothing to release on this track.
+                print("Beta and edge have the same version {}. We will not release.".format(beta_snap.version))
+                continue
+
+            print("Beta is at {}, edge at {}, and 'always_release' is {}.".format(
+                beta_snap.version, edge_snap.version, always_release
+            ))
+            edge_snap.test_cross_distro(channel_to_upgrade='beta', tests_branch=tests_branch)
+        else:
+            print("Beta channel is empty. Releasing without any testing.")
+
+        # The following will raise exceptions in case of a failure
+        edge_snap.release_to('beta', dry_run=dry_run)
+        edge_snap.release_to('candidate', dry_run=dry_run)

--- a/microk8s/release-to-edge-on-new-upstream-release.py
+++ b/microk8s/release-to-edge-on-new-upstream-release.py
@@ -2,12 +2,10 @@
 
 import requests
 import configbag
-import canonicalwebteam.snapstoreapi.public_api as public_api
+from snapstore import Microk8sSnap
 from launchpadlib.launchpad import Launchpad
 from lazr.restfulclient.errors import HTTPError
-
-
-tracks = ["latest", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15"]
+from configbag import tracks
 
 
 def upstream_release(release):
@@ -22,17 +20,6 @@ def upstream_release(release):
         return r.content.decode().strip()
     else:
         None
-
-
-def snapped_release(track):
-    """ Return the version of the microk8s snap in the edge channel and the track provided"""
-    snap_details = public_api.get_snap_details('microk8s', 'edge')
-    tracks = snap_details['channel_maps_list']
-    channel = "{}/edge".format(track) if track != "latest" else "edge"
-    versions = [c['version'] for t in tracks if t['track'] == track
-                for c in t['map'] if c['channel'] == channel]
-    version = versions[0] if versions else None
-    return version
 
 
 def trigger_lp_builders(track):
@@ -55,7 +42,7 @@ def trigger_lp_builders(track):
     try:
         # get snap
         microk8s = launchpad.snaps.getByName(name=snap_name,
-                                               owner=snappydev)
+                                             owner=snappydev)
     except HTTPError as e:
         print("Cannot trigger build for track {}. ({})".format(track, e.response))
         return None
@@ -74,9 +61,20 @@ if __name__ == '__main__':
         upstream = upstream_release(track)
         if not upstream:
             continue
-        snapped = snapped_release(track)
-        print("Upstream has {} and snapped version is at {}".format(upstream, snapped))
-        if upstream != snapped:
+        edge_snap = Microk8sSnap(track, 'edge')
+        if not edge_snap.released:
+            # Nothing released on edge. LP builders are probably not in place
+            continue
+        print("Upstream has {} and snapped version is at {}".format(upstream, edge_snap.version))
+        if upstream != edge_snap.version:
+            if not upstream.startswith("{}.".format(edge_snap.major_minor_version)):
+                # There is a minor version difference.
+                # For example upstream says we are on v1.12.x and the edge snap is on v1.11.y
+                # This should occur only in the "latest" track that follows the latest k8s
+                if track != 'latest':
+                    print("Track {} has an edge snap of {}.".format(track, edge_snap.version))
+                    raise Exception("Tracks should not change releases")
+
             print("Triggering LP builders")
             request = trigger_lp_builders(track)
             if request:

--- a/microk8s/release-to-stable.py
+++ b/microk8s/release-to-stable.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+
+import os
+from datetime import datetime, timezone
+from snapstore import Microk8sSnap
+from configbag import tracks
+
+
+# Set this to 'no' if you are sure you want to release
+dry_run = os.environ.get('DRY_RUN', 'yes')
+
+# Set this to 'yes' to bypass any check such as new version present.
+always_release = os.environ.get('ALWAYS_RELEASE', 'no')
+
+# If TESTS_BRANCH is not set the tests branch will be the one matching the track
+tests_branch = os.environ.get('TESTS_BRANCH')
+if tests_branch and tests_branch.strip() == '':
+    tests_branch = None
+
+# If you do not specify TRACKS all tracks will be processes
+tracks_requested = os.environ.get('TRACKS')
+if not tracks_requested or tracks_requested.strip() == '':
+    tracks_requested = tracks
+else:
+    tracks_requested = tracks_requested.split()
+
+
+if __name__ == '__main__':
+    '''
+    Releases to stable what is under candidate on the tracks provided in $TRACKS.
+    Cross distro tests should run.
+    '''
+    print("Check candidate maturity and release microk8s to stable.")
+    print("Dry run is set to '{}'.".format(dry_run))
+    for track in tracks_requested:
+        print("Looking at track {}".format(track))
+        candidate_snap = Microk8sSnap(track, 'candidate')
+        if not candidate_snap.released:
+            # Nothing to release
+            print("Nothing on candidate. Nothing to release.")
+            break
+
+        if (datetime.now(timezone.utc) - candidate_snap.release_date).days < 8 and always_release == 'no':
+            # Candidate not mature enough
+            print("Not releasing because candidate is {} days old and 'always_release' is {}".format(
+                (datetime.now(timezone.utc) - candidate_snap.release_date).days, always_release
+            ))
+            break
+
+        stable_snap = Microk8sSnap(track, 'stable')
+        if stable_snap.released:
+            # We already have a snap released on stable. Lets run some tests.
+            if candidate_snap.version == stable_snap.version and always_release == 'no':
+                # Candidate and stable are the same version. Nothing to release.
+                print("Beta and edge have the same version {}. We will not release.".format(stable_snap.version))
+                break
+
+            print("Candidate is at {}, stable at {}, and 'always_release' is {}.".format(
+                candidate_snap.version, stable_snap.version, always_release
+            ))
+            candidate_snap.test_cross_distro(channel_to_upgrade='stable', tests_branch=tests_branch)
+        else:
+            print("Stable channel is empty. Releasing without any testing.")
+
+        # The following will raise an exception if it fails
+        candidate_snap.release_to('stable', dry_run=dry_run)

--- a/microk8s/snapstore.py
+++ b/microk8s/snapstore.py
@@ -1,0 +1,94 @@
+import os
+from dateutil import parser
+from subprocess import check_output, check_call
+
+
+class Microk8sSnap:
+
+    def __init__(self, track, channel):
+        cmd = "snapcraft list-revisions microk8s --arch amd64".split()
+        revisions_list = check_output(cmd).decode("utf-8").split("\n")
+        if track == "latest":
+            channel_patern = " {}*".format(channel)
+        else:
+            channel_patern = " {}/{}*".format(track, channel)
+
+        revision_info_str = None
+        for revision in revisions_list:
+            if channel_patern in revision:
+                revision_info_str = revision
+        if revision_info_str:
+            # revision_info_str looks like this:
+            # "180     2018-09-12T15:51:33Z  amd64   v1.11.3    1.11/edge*"
+            revision_info = revision_info_str.split()
+
+            self.track = track
+            self.channel = channel
+            self.under_testing_channel = channel
+            if "edge" in self.under_testing_channel:
+                self.under_testing_channel = "{}/under-testing".format(self.under_testing_channel)
+            self.revision = revision_info[0]
+            self.version = revision_info[3]
+            version_parts = self.version.split('.')
+            self.major_minor_version = "{}.{}".format(version_parts[0], version_parts[1])
+            self.release_date = parser.parse(revision_info[1])
+            self.released = True
+        else:
+            self.released = False
+
+    def release_to(self, channel, dry_run="no"):
+        '''
+        Release the Snap to the input channel
+        Args:
+            channel: The channel to release to
+
+        '''
+        target = channel if self.track == "latest" else "{}/{}".format(self.track, channel)
+        cmd = "snapcraft release microk8s {} {}".format(self.revision, target)
+        if dry_run == "no":
+            check_call(cmd.split())
+        else:
+            print("DRY RUN - calling: {}".format(cmd))
+
+    def test_cross_distro(self,  channel_to_upgrade='stable',
+                          tests_branch=None,
+                          distributions = ["ubuntu:16.04", "ubuntu:18.04"]):
+        '''
+        Test the channel this snap came from and make sure we can upgrade the
+        channel_to_upgrade. Tests are run on the distributions distros.
+
+        Args:
+            channel_to_upgrade: what channel to try to upgrade
+            tests_branch: the branch where tests live. Normally next to the released code.
+            distributions: where to run tests on
+
+        '''
+        # Get the microk8s source where the tests are. Switch to the branch
+        # that matches the track we are going to release to.
+        cmd = "rm -rf microk8s".split()
+        check_call(cmd)
+        cmd = "git clone http://www.github.com/ubuntu/microk8s".split()
+        check_call(cmd)
+        os.chdir("microk8s")
+        if not tests_branch:
+            if self.track == 'latest':
+                tests_branch = 'master'
+            else:
+                tests_branch = self.track
+        print("Tests are taken from branch {}".format(tests_branch))
+        cmd = "git checkout {}".format(tests_branch).split()
+        check_call(cmd)
+
+        if "under-testing" in self.under_testing_channel:
+            self.release_to(self.under_testing_channel)
+        for distro in distributions:
+            if self.track == "latest":
+                track_channel_to_upgrade = channel_to_upgrade
+                testing_track_channel = self.under_testing_channel
+            else:
+                track_channel_to_upgrade = "{}/{}".format(self.track, channel_to_upgrade)
+                testing_track_channel = "{}/{}".format(self.track, self.under_testing_channel)
+
+            cmd = "tests/test-distro.sh {} {} {}".format(distro, track_channel_to_upgrade,
+                                                         testing_track_channel).split()
+            check_call(cmd)


### PR DESCRIPTION
@battlemidget, these are the scripts for releasing microk8s.

I am adding them here so as to get a review before we create the job/build-microk8s files.

---

Please make sure to open PR's against the correct code:

- For Integration tests (test_cdk.py) please make those changes in `jobs/integration`
- For microk8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`

