### PR TITLE
Fix permission denied during rm -rf ./release

### DIFF
--- a/jobs/build-snaps/build.sh
+++ b/jobs/build-snaps/build.sh
@@ -20,7 +20,7 @@ ADDONS_BRANCH_VERSION="release-${VERSION}"
 
 source $scripts_path/retry.sh
 
-rm -rf ./release
+sudo rm -rf ./release
 git clone https://github.com/juju-solutions/release.git --branch rye/snaps --depth 1
 (cd release/snap
   make KUBE_VERSION=$KUBE_VERSION KUBE_ARCH="$KUBE_ARCH" \


### PR DESCRIPTION
The build-release-snaps job failed with "Permission denied" on `rm -rf ./release`. I'm pretty sure it's because the snaps are built in a docker container and the permissions on the resulting build files are messed up. This is a quick fix.

@battlemidget this PR targets the k8sci branch. Please let me know if that's not correct.