### PR TITLE
Make it possible to run test_cdk.py without BUILD_NUMBER

### DIFF
--- a/jobs/integration/base.py
+++ b/jobs/integration/base.py
@@ -4,12 +4,17 @@ from juju.model import Model
 from sh import juju_wait
 
 
+
+def _model_from_env():
+    return os.environ.get('MODEL') or \
+        'validate-{}'.format(os.environ['BUILD_NUMBER'])
+
+
 def _juju_wait(controller=None, model=None):
     if not controller:
         controller = os.environ.get('CONTROLLER', 'jenkins-ci-aws')
     if not model:
-        model = os.environ.get(
-            'MODEL', 'validate-{}'.format(os.environ['BUILD_NUMBER']))
+        model = _model_from_env()
     print("Settling...")
     juju_wait('-e', "{}:{}".format(controller, model), '-w')
 
@@ -22,8 +27,7 @@ class UseModel:
     """
     def __init__(self):
         self._controller_name = os.environ.get('CONTROLLER', 'jenkins-ci-aws')
-        self._model_name = os.environ.get(
-            'MODEL', 'validate-{}'.format(os.environ['BUILD_NUMBER']))
+        self._model_name = _model_from_env()
         self._model = None
 
     @property


### PR DESCRIPTION
Encountered this while trying to test locally:

```
$ CONTROLLER=aws-dev MODEL=default CLOUD=aws tox -e py36 -- pytest -s --no-print-logs integration/test_cdk.py::test_validate
...
____________________________________________________ test_validate ____________________________________________________

log_dir = 'logs/integration.test_cdk/test_validate'

    @pytest.mark.asyncio
    async def test_validate(log_dir):
        """ Validates and existing CDK deployment
        """
>       async with UseModel() as model:

integration/test_cdk.py:21: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
integration/base.py:26: in __init__
    'MODEL', 'validate-{}'.format(os.environ['BUILD_NUMBER']))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = environ({'GOPATH': '/home/gkk/work/gopath', 'XDG_GREETER_DATA_DIR': '/var/lib/lightdm-data/gkk', 'LESSOPEN': '| /usr/b...spx=00;36:*.xspf=00;36:', 'XDG_SEAT': 'seat0', 'PYTEST_CURRENT_TEST': 'integration/test_cdk.py::test_validate (call)'})
key = 'BUILD_NUMBER'

    def __getitem__(self, key):
        try:
            value = self._data[self.encodekey(key)]
        except KeyError:
            # raise KeyError with the original key value
>           raise KeyError(key) from None
E           KeyError: 'BUILD_NUMBER'

.tox/py36/lib/python3.6/os.py:669: KeyError
```

This PR fixes it. @battlemidget 