### PR TITLE
Create LP microk8s builders for AMD64 and ARM64 processors

### DIFF
--- a/microk8s/update-gh-branches-and-lp-builders.py
+++ b/microk8s/update-gh-branches-and-lp-builders.py
@@ -126,6 +126,7 @@ class Builder:
                             store_name=workingsnap.store_name,
                             store_series=workingsnap.store_series,
                             store_channels="{}/edge/testingbuilders".format(self.track),
+                            processors=['/+processors/amd64', '/+processors/arm64'],
                             auto_build=workingsnap.auto_build,
                             auto_build_archive=workingsnap.auto_build_archive,
                             auto_build_pocket=workingsnap.auto_build_pocket)


### PR DESCRIPTION
@battlemidget we will need a job for the `microk8s/update-gh-branches-and-lp-builders.py` script that would run 2-3 times per day. This script is very light. It makes sure we branch the code for upstream k8s releases and also creates the LP builders. Thank you. 