### PR TITLE
Rework test_docker_proposed.py to use cloudinit-userdata

### DIFF
--- a/jobs/integration/test_docker_proposed.py
+++ b/jobs/integration/test_docker_proposed.py
@@ -1,84 +1,41 @@
-import os
 import pytest
-import subprocess
 import yaml
-from .base import (UseModel,
-                   _model_from_env,
-                   _controller_from_env,
-                   _juju_wait)
-from .utils import juju_deploy, asyncify
+from .base import UseModel, _juju_wait
+from .utils import asyncify
 from .validation import validate_all
-from .logger import log
+from .logger import log, log_calls_async
 
 
-async def enable_proposed_on(target, series='bionic'):
-    log('Enabling {}-proposed on {}'.format(series, target))
+@log_calls_async
+async def enable_proposed_on_model(model, series='bionic'):
     apt_line = 'deb http://archive.ubuntu.com/ubuntu/ {}-proposed restricted main multiverse universe'.format(series)
-    apt_source_list = '/etc/apt/sources.list.d/{}-proposed.list'.format(series)
-    remote_cmd = 'echo %s | sudo tee %s && sudo apt update' % (apt_line, apt_source_list)
-    cmd = ['juju', 'ssh', '-m',
-           '{}:{}'.format(_controller_from_env(), _model_from_env()),
-           target, remote_cmd]
-    while True:
-        log("Running " + str(cmd))
-        code = await asyncify(subprocess.call)(cmd)
-        if code == 0:
-            break
+    dest = '/etc/apt/sources.list.d/{}-proposed.list'.format(series)
+    cmd = 'echo %s > %s' % (apt_line, dest)
+    cloudinit_userdata = {'postruncmd': [cmd]}
+    cloudinit_userdata_str = yaml.dump(cloudinit_userdata)
+    await model.set_config({'cloudinit-userdata': cloudinit_userdata_str})
 
 
 async def log_docker_versions(model):
-    app = model.applications['kubernetes-worker']
-    for unit in app.units:
-        action = await unit.run('docker --version')
-        docker_version = action.data['results']['Stdout']
-        log(unit.name + ': ' + docker_version)
+    log('Logging docker versions')
+    for app in model.applications.values():
+        for unit in app.units:
+            action = await unit.run('docker --version')
+            docker_version = action.data['results']['Stdout'].strip() or 'Docker not installed'
+            log(unit.name + ': ' + docker_version)
 
 
 @pytest.mark.asyncio
 async def test_docker_proposed(log_dir):
     async with UseModel() as model:
-        # Deploy bundle with 0 worker units
-        url = 'cs:~containers/canonical-kubernetes'
-        bundle_dir = os.path.join(log_dir, 'bundle')
-        cmd = ['charm', 'pull', url, bundle_dir, '--channel', 'edge']
-        await asyncify(subprocess.check_call)(cmd)
-        data_path = os.path.join(bundle_dir, 'bundle.yaml')
-        with open(data_path) as f:
-            data = yaml.load(f)
-        data['services']['kubernetes-worker']['num_units'] = 0
-        with open(data_path, 'w') as f:
-            yaml.dump(data, f)
-        await model.deploy(bundle_dir)
+        # Enable <series>-proposed on this model
+        await enable_proposed_on_model(model)
+
+        # Deploy cdk
+        await model.deploy('cs:~containers/canonical-kubernetes', channel='edge')
         await asyncify(_juju_wait)()
 
-        # Add worker machine with series enabled
-        constraints_str = data['services']['kubernetes-worker']['constraints']
-        # I don't feel like writing a constraint parser right now
-        assert constraints_str == 'cores=4 mem=4G root-disk=16G', "Test assumption is no longer true"
-        constraints = {'cores': 4, 'mem': 4 * 1024}
-        machine = await model.add_machine(constraints=constraints)
-        await enable_proposed_on(machine.id)
-
-        # Add worker unit to machine
-        app = model.applications['kubernetes-worker']
-        await app.add_unit(to=machine.id)
-        await asyncify(_juju_wait)()
-        # Now do the usual.
-        await log_docker_versions(model)
+        # Run validation
+        await log_docker_versions(model)  # log before run
         await validate_all(model, log_dir)
-
-
-@pytest.mark.asyncio
-async def test_docker_proposed_upgrade(log_dir):
-    async with UseModel() as model:
-        # await juju_deploy(model, 'containers', 'canonical-kubernetes')
-
-        worker_units = model.applications['kubernetes-worker'].units
-        for unit in worker_units:
-            log('Enabling {}-proposed and updating docker.io on {}'.format(series, unit.name))
-            await enable_proposed_on(unit.name)
-            await unit.run('apt install docker.io')
-
-        await asyncify(_juju_wait)()
-        await log_docker_versions(model)
-        await validate_all(model, log_dir)
+        await log_docker_versions(model)  # log after run


### PR DESCRIPTION
The original `test_docker_proposed.py` had a problem: when `validate_worker_master_removal` ran, it would remove the unit that installed from bionic-proposed, and replace it with one that did not.

This PR reworks the new `test_docker_proposed.py` to use cloudinit-userdata instead. This makes it so any newly created machine in the model will have bionic-proposed enabled, not just the one machine at the beginning of the test run. As a bonus, using cloudinit-userdata simplifies the test quite a bit.

I also removed `test_docker_proposed_upgrade` since I don't think it's a valid test case. The charms freeze the docker.io package. We do not support upgrading docker on existing machines in a live deployment unless you cordon and drain the worker prior to upgrading.