### PR TITLE
Fix test_docker_proposed to allow both bionic and xenial units

### DIFF
--- a/jobs/integration/test_docker_proposed.py
+++ b/jobs/integration/test_docker_proposed.py
@@ -7,9 +7,10 @@ from .logger import log, log_calls_async
 
 
 @log_calls_async
-async def enable_proposed_on_model(model, series='bionic'):
-    apt_line = 'deb http://archive.ubuntu.com/ubuntu/ {}-proposed restricted main multiverse universe'.format(series)
-    dest = '/etc/apt/sources.list.d/{}-proposed.list'.format(series)
+async def enable_proposed_on_model(model):
+    archive = '$(lsb_release -cs)-proposed'
+    apt_line = 'deb http://archive.ubuntu.com/ubuntu/ {} restricted main multiverse universe'.format(archive)
+    dest = '/etc/apt/sources.list.d/{}.list'.format(archive)
     cmd = 'echo %s > %s' % (apt_line, dest)
     cloudinit_userdata = {'postruncmd': [cmd]}
     cloudinit_userdata_str = yaml.dump(cloudinit_userdata)


### PR DESCRIPTION
@battlemidget This should hopefully fix the issue seen in validate-docker-proposed build 9, which failed during `validate_keystone`.

I think the failure occurred because keystone was deployed on a xenial machine, but the test added bionic-proposed to its apt sources instead of xenial-proposed. Oops!

This hopefully fixes it by having the cloudinit-userdata run `lsb_release -cs` on each machine, instead of assuming bionic.