### PR TITLE
add logging for audit failure

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -751,6 +751,7 @@ async def validate_sans(model):
         await lb.set_config({'extra_sans': original_lb_config['extra_sans']['value']})
 
 
+@log_calls_async
 async def run_until_success(unit, cmd, timeout_insec=None):
     while True:
         action = await unit.run(cmd, timeout=timeout_insec)
@@ -972,6 +973,7 @@ async def validate_docker_logins(model):
     await cleanup()
 
 
+@log_calls_async
 async def get_last_audit_entry_date(unit):
     cmd = 'cat /root/cdk/audit/audit.log | tail -n 1'
     raw = await run_until_success(unit, cmd)


### PR DESCRIPTION
It's not clear exactly where the test is hanging, it could be anywhere in here:
https://github.com/juju-solutions/kubernetes-jenkins/blob/f2e4a41f4715aa50a2b710346bffa35b7ffdfab5/jobs/integration/validation.py#L1115-L1125

Adding this call logging should help us narrow it down.