### PR TITLE
Adding the proxy parameter to the microk8s jobs

### DIFF
--- a/jobs/microk8s/release-to-beta.py
+++ b/jobs/microk8s/release-to-beta.py
@@ -23,6 +23,11 @@ if not tracks_requested or tracks_requested.strip() == '':
 else:
     tracks_requested = tracks_requested.split()
 
+# Set this to the proxy your environment may have
+proxy = os.environ.get('PROXY')
+if not proxy or proxy.strip() == '':
+    proxy = None
+
 
 if __name__ == '__main__':
     '''
@@ -49,7 +54,9 @@ if __name__ == '__main__':
             print("Beta is at {}, edge at {}, and 'always_release' is {}.".format(
                 beta_snap.version, edge_snap.version, always_release
             ))
-            edge_snap.test_cross_distro(channel_to_upgrade='beta', tests_branch=tests_branch)
+            edge_snap.test_cross_distro(channel_to_upgrade='beta',
+                                        tests_branch=tests_branch,
+                                        proxy=proxy)
         else:
             print("Beta channel is empty. Releasing without any testing.")
 

--- a/jobs/microk8s/release-to-stable.py
+++ b/jobs/microk8s/release-to-stable.py
@@ -24,6 +24,11 @@ if not tracks_requested or tracks_requested.strip() == '':
 else:
     tracks_requested = tracks_requested.split()
 
+# Set this to the proxy your environment may have
+proxy = os.environ.get('PROXY')
+if not proxy or proxy.strip() == '':
+    proxy = None
+
 
 if __name__ == '__main__':
     '''
@@ -58,7 +63,9 @@ if __name__ == '__main__':
             print("Candidate is at {}, stable at {}, and 'always_release' is {}.".format(
                 candidate_snap.version, stable_snap.version, always_release
             ))
-            candidate_snap.test_cross_distro(channel_to_upgrade='stable', tests_branch=tests_branch)
+            candidate_snap.test_cross_distro(channel_to_upgrade='stable',
+                                             tests_branch=tests_branch,
+                                             proxy=proxy)
         else:
             print("Stable channel is empty. Releasing without any testing.")
 

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -52,7 +52,8 @@ class Microk8sSnap:
 
     def test_cross_distro(self,  channel_to_upgrade='stable',
                           tests_branch=None,
-                          distributions = ["ubuntu:16.04", "ubuntu:18.04"]):
+                          distributions=["ubuntu:16.04", "ubuntu:18.04"],
+                          proxy=None):
         '''
         Test the channel this snap came from and make sure we can upgrade the
         channel_to_upgrade. Tests are run on the distributions distros.
@@ -61,6 +62,7 @@ class Microk8sSnap:
             channel_to_upgrade: what channel to try to upgrade
             tests_branch: the branch where tests live. Normally next to the released code.
             distributions: where to run tests on
+            proxy: Proxy URL to pass to the tests
 
         '''
         # Get the microk8s source where the tests are. Switch to the branch
@@ -100,4 +102,6 @@ class Microk8sSnap:
 
             cmd = "sudo tests/test-distro.sh {} {} {}".format(distro, track_channel_to_upgrade,
                                                               testing_track_channel).split()
+            if proxy:
+                cmd.append(proxy)
             check_call(cmd)

--- a/jobs/release-microk8s-beta/Jenkinsfile
+++ b/jobs/release-microk8s-beta/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         string(name: 'ALWAYS_RELEASE', defaultValue: 'no', description: 'This script will release only on a new patch release. Set this to "yes" if we need to release to beta even if the patch release number is the same.')
         string(name: 'TRACKS', defaultValue: '', description: 'The tracks you want to test and release. For example latest 1.10 1.11 1.12. Leave empty to iterate over all tracks.')
         string(name: 'TESTS_BRANCH', defaultValue: '', description: 'You might want to test with a set of tests that are in your own branch. Here is where you set the branch name.')
+        string(name: 'PROXY', defaultValue: 'http://squid.internal:3128', description: 'Proxy endpoint')
     }
     options {
         ansiColor('xterm')
@@ -31,7 +32,7 @@ pipeline {
         stage('Release microk8s'){
             steps {
                 dir('jobs') {
-                    sh "DRY_RUN=${params.DRY_RUN} ALWAYS_RELEASE=${params.ALWAYS_RELEASE} TRACKS=${params.TRACKS} TESTS_BRANCH=${params.TESTS_BRANCH} tox -e py36 -- python3 microk8s/release-to-beta.py"
+                    sh "DRY_RUN=${params.DRY_RUN} ALWAYS_RELEASE=${params.ALWAYS_RELEASE} TRACKS=${params.TRACKS} TESTS_BRANCH=${params.TESTS_BRANCH} PROXY=${params.PROXY} tox -e py36 -- python3 microk8s/release-to-beta.py"
                 }
             }
         }

--- a/jobs/release-microk8s-stable/Jenkinsfile
+++ b/jobs/release-microk8s-stable/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         string(name: 'ALWAYS_RELEASE', defaultValue: 'no', description: 'This script will release only on a new patch release. Set this to "yes" if we need to release to beta even if the patch release number is the same.')
         string(name: 'TRACKS', defaultValue: '', description: 'The tracks you want to test and release. For example latest 1.10 1.11 1.12. Leave empty to iterate over all tracks.')
         string(name: 'TESTS_BRANCH', defaultValue: '', description: 'You might want to test with a set of tests that are in your own branch. Here is where you set the branch name.')
+        string(name: 'PROXY', defaultValue: 'http://squid.internal:3128', description: 'Proxy endpoint')
     }
     options {
         ansiColor('xterm')
@@ -30,7 +31,7 @@ pipeline {
         stage('Release microk8s'){
             steps {
                 dir('jobs') {
-                    sh "DRY_RUN=${params.DRY_RUN} ALWAYS_RELEASE=${params.ALWAYS_RELEASE} TRACKS=${params.TRACKS} TESTS_BRANCH=${params.TESTS_BRANCH} tox -e py36 -- python3 microk8s/release-to-stable.py"
+                    sh "DRY_RUN=${params.DRY_RUN} ALWAYS_RELEASE=${params.ALWAYS_RELEASE} TRACKS=${params.TRACKS} TESTS_BRANCH=${params.TESTS_BRANCH} PROXY=${params.PROXY} tox -e py36 -- python3 microk8s/release-to-stable.py"
                 }
             }
         }


### PR DESCRIPTION
@battlemidget this is required to pass the proxy uri to the microk8s tests.

There was a series of green tests when setting the proxy, so lets merge this and redeploy the jobs and then I will work on the PRS on the ubuntu/microk8s repo.

Thanks