### PR TITLE
Microk8s tests tuned for arm64

### DIFF
--- a/jobs/microk8s/configbag.py
+++ b/jobs/microk8s/configbag.py
@@ -1,6 +1,32 @@
 import os
+import platform
 
-tracks = ["latest", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15"]
+
+def get_arch():
+    '''
+    Returns: the current architecture
+
+    '''
+    arch_translate = {
+        'aarch64': 'arm64',
+        'x86_64': 'amd64'
+    }
+
+    return arch_translate[platform.machine()]
+
+
+def get_tracks(all=False):
+    '''
+
+    Returns: the tracks valid for the architecture at hand
+
+    '''
+    arch = get_arch()
+    if arch == 'arm64' and not all:
+        return ["latest", "1.12", "1.13", "1.14", "1.15"]
+    else:
+        return ["latest", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15"]
+
 
 snap_name = "microk8s"
 people_name = "microk8s-dev"

--- a/jobs/microk8s/release-to-beta.py
+++ b/jobs/microk8s/release-to-beta.py
@@ -2,7 +2,7 @@
 
 import os
 from snapstore import Microk8sSnap
-from configbag import tracks
+from configbag import get_tracks
 
 
 # Set this to 'no' if you are sure you want to release
@@ -19,7 +19,7 @@ if tests_branch and tests_branch.strip() == '':
 # If you do not specify TRACKS all tracks will be processes
 tracks_requested = os.environ.get('TRACKS')
 if not tracks_requested or tracks_requested.strip() == '':
-    tracks_requested = tracks
+    tracks_requested = get_tracks()
 else:
     tracks_requested = tracks_requested.split()
 

--- a/jobs/microk8s/release-to-edge-on-new-upstream-release.py
+++ b/jobs/microk8s/release-to-edge-on-new-upstream-release.py
@@ -5,7 +5,7 @@ import configbag
 from snapstore import Microk8sSnap
 from launchpadlib.launchpad import Launchpad
 from lazr.restfulclient.errors import HTTPError
-from configbag import tracks
+from configbag import get_tracks
 
 
 def upstream_release(release):
@@ -56,7 +56,7 @@ def trigger_lp_builders(track):
 
 if __name__ == '__main__':
     print("Running a build and release of microk8s")
-    for track in tracks:
+    for track in get_tracks(all=True):
         print("Looking at track {}".format(track))
         upstream = upstream_release(track)
         if not upstream:

--- a/jobs/microk8s/release-to-stable.py
+++ b/jobs/microk8s/release-to-stable.py
@@ -3,7 +3,7 @@
 import os
 from datetime import datetime, timezone
 from snapstore import Microk8sSnap
-from configbag import tracks
+from configbag import get_tracks
 
 
 # Set this to 'no' if you are sure you want to release
@@ -20,7 +20,7 @@ if tests_branch and tests_branch.strip() == '':
 # If you do not specify TRACKS all tracks will be processes
 tracks_requested = os.environ.get('TRACKS')
 if not tracks_requested or tracks_requested.strip() == '':
-    tracks_requested = tracks
+    tracks_requested = get_tracks()
 else:
     tracks_requested = tracks_requested.split()
 

--- a/jobs/microk8s/snapstore.py
+++ b/jobs/microk8s/snapstore.py
@@ -1,4 +1,5 @@
 import os
+import configbag
 from dateutil import parser
 from subprocess import check_output, check_call, CalledProcessError
 
@@ -6,7 +7,8 @@ from subprocess import check_output, check_call, CalledProcessError
 class Microk8sSnap:
 
     def __init__(self, track, channel):
-        cmd = "snapcraft list-revisions microk8s --arch amd64".split()
+        arch = configbag.get_arch()
+        cmd = "snapcraft list-revisions microk8s --arch {}".format(arch).split()
         revisions_list = check_output(cmd).decode("utf-8").split("\n")
         if track == "latest":
             channel_patern = " {}*".format(channel)

--- a/jobs/microk8s/update-gh-branches-and-lp-builders.py
+++ b/jobs/microk8s/update-gh-branches-and-lp-builders.py
@@ -5,7 +5,7 @@ import requests
 import configbag
 from launchpadlib.launchpad import Launchpad
 from lazr.restfulclient.errors import HTTPError
-from configbag import tracks
+from configbag import get_tracks
 from subprocess import check_call, CalledProcessError
 
 
@@ -176,7 +176,7 @@ class Builder:
 
 if __name__ == '__main__':
     print("Validating GH branches and LP builders of microk8s")
-    for track in tracks:
+    for track in get_tracks(all=True):
         print("Examining track {}".format(track))
         upstream = upstream_release(track)
         if not upstream:


### PR DESCRIPTION
@battlemidget this is the first part of the work of testing microk8s on arm64. Two things happen here:

- arm64 is available on the 1.12+ tracks
- when looking for revisions to release we query only for those on the right arch

There is going to be a second PR with work on the pipelines. I am splinting the work into to PRs because I am only certain about this PR.