### PR TITLE
Parallelise microk8s builds

### DIFF
--- a/jobs/release-microk8s-beta.yaml
+++ b/jobs/release-microk8s-beta.yaml
@@ -1,12 +1,18 @@
-- job:
-    name: 'release-microk8s-beta'
+# Tests and releases microk8s to beta
+
+- job-template:
+    name: 'release-microk8s-beta-{arch}'
     description: |
-      Tests and releases microk8s to beta. Affects all tracks.
+      Tests and releases microk8s to beta. Affects all tracks on {arch}.
     project-type: pipeline
     pipeline-scm:
       scm:
         - k8s-jenkins-jenkaas
       script-path: jobs/release-microk8s-beta/Jenkinsfile
+    parameters:
+      - string:
+          name: build_node
+          default: 'runner-{arch}'
     triggers:
         - timed: "0 0 * * *"
     properties:
@@ -19,3 +25,14 @@
             - "infra.*"
           block-level: 'GLOBAL'
           queue-scanning: 'ALL'
+
+- job-group:
+    name: 'release-microk8s-beta'
+    jobs:
+      - 'release-microk8s-beta-{arch}':
+          arch: ['amd64', 'arm64']
+
+- project:
+    name: release-microk8s-beta
+    jobs:
+      - 'release-microk8s-beta'

--- a/jobs/release-microk8s-beta/Jenkinsfile
+++ b/jobs/release-microk8s-beta/Jenkinsfile
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'runner-amd64'
+        label "${params.build_node}"
     }
     /* XXX: Global $PATH setting doesn't translate properly in pipelines
      https://stackoverflow.com/questions/43987005/jenkins-does-not-recognize-command-sh

--- a/jobs/release-microk8s-stable.yaml
+++ b/jobs/release-microk8s-stable.yaml
@@ -1,12 +1,18 @@
-- job:
-    name: 'release-microk8s-stable'
+# Tests and releases microk8s to stable
+
+- job-template:
+    name: 'release-microk8s-stable-{arch}'
     description: |
-      Tests and releases microk8s to stable. Affects all tracks.
+      Tests and releases microk8s to stable. Affects all tracks on {arch}.
     project-type: pipeline
     pipeline-scm:
       scm:
         - k8s-jenkins-jenkaas
       script-path: jobs/release-microk8s-stable/Jenkinsfile
+    parameters:
+      - string:
+          name: build_node
+          default: 'runner-{arch}'
     triggers:
         - timed: "0 12 * * *"
     properties:
@@ -19,3 +25,14 @@
             - "infra.*"
           block-level: 'GLOBAL'
           queue-scanning: 'ALL'
+
+- job-group:
+    name: 'release-microk8s-stable'
+    jobs:
+      - 'release-microk8s-stable-{arch}':
+          arch: ['amd64', 'arm64']
+
+- project:
+    name: release-microk8s-stable
+    jobs:
+      - 'release-microk8s-stable'

--- a/jobs/release-microk8s-stable/Jenkinsfile
+++ b/jobs/release-microk8s-stable/Jenkinsfile
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'runner-amd64'
+        label "${params.build_node}"
     }
     /* XXX: Global $PATH setting doesn't translate properly in pipelines
      https://stackoverflow.com/questions/43987005/jenkins-does-not-recognize-command-sh


### PR DESCRIPTION
@battlemidget this is the second PR with work on microk8s multiarch. What i tried to do is to have the same tests running on amd64 and arm64. As long as the right agent is selected the tests will pick up the architecture and push to beta and stable the right snap revision.

Cannot say if this syntax works though, I need your help. Thanks.
