### PR TITLE
Fix bundle error in Vault test

### DIFF
--- a/jobs/overlays/1.12-edge-vault-overlay.yaml
+++ b/jobs/overlays/1.12-edge-vault-overlay.yaml
@@ -8,6 +8,7 @@ applications:
   easyrsa:
     # it's currently not possible to remove an application in an overlay
     num_units: 0
+    to: []
   vault:
     charm: cs:~openstack-charmers-next/vault
     num_units: 1


### PR DESCRIPTION
```
too many units specified in unit placement for application "easyrsa"
```

The overlay sets the `num_units` to 0 but there is still a placement directive. This updates the overlay to clear out the placement directive.