### PR TITLE
Fix conflict between Keystone and Vault tests

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1208,9 +1208,11 @@ async def validate_keystone(model):
                        config={'admin-password': 'testpw',
                                'preferred-api-version': '3',
                                'openstack-origin': 'cloud:bionic-rocky'})
-    await model.deploy('percona-cluster',
-                       config={'innodb-buffer-pool-size': '256M',
-                               'max-connections': '1000'})
+    if 'percona-cluster' not in model.applications:
+        # probably already deployed by the Vault test
+        await model.deploy('percona-cluster',
+                           config={'innodb-buffer-pool-size': '256M',
+                                   'max-connections': '1000'})
     await model.add_relation('kubernetes-master:keystone-credentials',
                              'keystone:identity-credentials')
     await model.add_relation('keystone:shared-db', 'percona-cluster:shared-db')

--- a/jobs/overlays/1.12-edge-vault-overlay.yaml
+++ b/jobs/overlays/1.12-edge-vault-overlay.yaml
@@ -18,6 +18,9 @@ applications:
   percona-cluster:
     charm: cs:percona-cluster
     num_units: 1
+    options:
+      innodb-buffer-pool-size: '256M'
+      max-connections: '1000'
 relations:
   - ['vault:shared-db', 'percona-cluster:shared-db']
   - ['vault:secrets', 'kubernetes-master:vault-kv']


### PR DESCRIPTION
Both use percona-cluster and there was a conflict with how they were deploying it.