### PR TITLE
Fix use of wrong run result attribute in Vault test

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1408,14 +1408,14 @@ async def validate_encryption_at_rest(model):
         # read secret
         output = await worker.run("kubectl get secret test-secret -o yaml")
         assert output.status == 'completed'
-        assert 'secret-value' in output.output
+        assert 'secret-value' in output.results['Stdout']
         # verify secret is encrypted
         etcd = model.applications['etcd'].units[0]
         etcd.run("ETCDCTL_API=3 /snap/bin/etcd.etcdctl "
                  "--endpoints http://127.0.0.1:4001 "
                  "get /registry/secrets/default/test-secret | hexdump -C")
         assert output.status == 'completed'
-        assert 'secret-value' not in output.output
+        assert 'secret-value' not in output.results['Stdout']
     finally:
         # cleanup
         (done1, pending1) = await asyncio.wait({


### PR DESCRIPTION
Fixes the latest error on CI:

```
08:04:39 Traceback (most recent call last):
08:04:39   File "/var/lib/jenkins/slaves/jenkins-slave-1/workspace/validate-vault-v1.12.x/jobs/integration/logger.py", line 47, in wrapper
08:04:39     result = await f(*args, **kwargs)
08:04:39   File "/var/lib/jenkins/slaves/jenkins-slave-1/workspace/validate-vault-v1.12.x/jobs/integration/validation.py", line 1367, in validate_encryption_at_rest
08:04:39     assert 'secret-value' in output.output
08:04:39   File "/var/lib/jenkins/.tox/py36/lib/python3.6/site-packages/juju/model.py", line 253, in __getattr__
08:04:39     return self.safe_data[name]
08:04:39 KeyError: 'output'
```