### PR TITLE
Add missing flannel-s390x resource spec

### DIFF
--- a/jobs/build-charms/resource-spec.yaml
+++ b/jobs/build-charms/resource-spec.yaml
@@ -9,6 +9,7 @@
 'cs:~containers/flannel':
   flannel-amd64.tar.gz: flannel-amd64
   flannel-arm64.tar.gz: flannel-arm64
+  flannel-s390x.tar.gz: flannel-s390x
 'cs:~containers/kubernetes-worker':
   cni-amd64.tgz: cni-amd64
   cni-arm64.tgz: cni-arm64


### PR DESCRIPTION
@battlemidget I noticed the flannel-s390x resource isn't getting updated. This should fix it.