### PR TITLE
Fix cdk-addons release branch creation

### DIFF
--- a/jobs/build-snaps/promote.sh
+++ b/jobs/build-snaps/promote.sh
@@ -41,7 +41,7 @@ create_git_branch_if_not_exists () {
       echo "GH_USER or GH_TOKEN not set, not creating branch for stable promotion release-${1}."
     else
       echo "Creating new branch for release-${1}."
-      create_branch "juju-solutions" "cdk-addons" ${GH_USER} ${GH_TOKEN} $1
+      create_branch "juju-solutions" "cdk-addons" ${GH_USER} ${GH_TOKEN} release-$1
     fi
   fi
 }


### PR DESCRIPTION
We ended up with [branches on cdk-addons](https://github.com/juju-solutions/cdk-addons/branches/all) named `1.12` and `1.13`. They should have been `release-1.12` and `release-1.13`. This is important because without the `release-` prefix, the [cdk-addons build script](https://github.com/juju-solutions/kubernetes-jenkins/blob/45638d77e7b57c13a3fa1625f8b796789b80b3ad/jobs/build-snaps/build.sh#L18) will not use them.

This PR should fix the branch creation to include the `release-` prefix.