### PR TITLE
Removing namespace delete in Jenkinsfile

### DIFF
--- a/jobs/validate-kubeflow-microk8s/Jenkinsfile
+++ b/jobs/validate-kubeflow-microk8s/Jenkinsfile
@@ -59,7 +59,6 @@ pipeline {
             collectDebug(params.controller, juju_model)
             sh "juju kill-controller -y ${params.controller} || true"
             sh "juju remove-cloud ${cloud}"
-            sh "microk8s.kubectl delete ns ${juju_model}"
             sh "microk8s.docker rmi ${mnist_image}"
         }
     }


### PR DESCRIPTION
The namespace already gets deleted as part of the kill-controller command