### PR TITLE
Updating Kubeflow charm store namespace

### DIFF
--- a/jobs/validate-kubeflow-aws/Jenkinsfile
+++ b/jobs/validate-kubeflow-aws/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                 sh "juju add-model ${k8s_model} aws-kf-cloud"
                 sh "juju create-storage-pool operator-storage kubernetes storage-class=juju-operator-storage storage-provisioner=kubernetes.io/aws-ebs parameters.type=gp2"
                 sh "juju create-storage-pool k8s-ebs kubernetes storage-class=juju-ebs storage-provisioner=kubernetes.io/aws-ebs parameters.type=gp2"
-                sh "juju deploy cs:~juju/kubeflow"
+                sh "juju deploy cs:~kubeflow-charmers/kubeflow"
                 sh "juju wait -e aws-us-east-1:${k8s_model} -w"
             }
         }

--- a/jobs/validate-kubeflow-microk8s/Jenkinsfile
+++ b/jobs/validate-kubeflow-microk8s/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
 
                 sh "juju add-model ${juju_model} ${cloud}"
                 sh "juju create-storage-pool operator-storage kubernetes storage-class=microk8s-hostpath"
-                sh "juju deploy cs:~juju/kubeflow"
+                sh "juju deploy cs:~kubeflow-charmers/kubeflow"
 
                 sh "juju-wait -e ${params.controller}:${juju_model} -w"
             }


### PR DESCRIPTION
We will be publishing these to `kubeflow-charmers` instead of `juju`.

This won't currently work since we haven't yet pushed those charms up, but it also doesn't currently work due to interaction between tensorflow serving and juju wait, which will be fixed when we push those charms up.
