### PR TITLE
Parameterizing charm store namespace

### DIFF
--- a/jobs/build-charms.yaml
+++ b/jobs/build-charms.yaml
@@ -25,6 +25,7 @@
 
     # Defaults
     resource_build_sh: ''
+    namespace: 'containers'
 
     description: |
       Builds and releases {charm} to charmstore edge channel.
@@ -46,6 +47,9 @@
       - string:
           name: cloud
           default: 'aws/us-east-1'
+      - string:
+          name: namespace
+          default: '{namespace}'
       - string:
           name: repo_name
           default: '{repo_name}'
@@ -102,27 +106,35 @@
           repo_name: 'docker-registry-charm'
           git_repo: 'https://github.com/CanonicalLtd/docker-registry-charm.git'
       - 'kubeflow-ambassador':
+          namespace: 'kubeflow-charmers'
           repo_name: 'charm-kubeflow-ambassador'
           git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
       - 'kubeflow-pytorch-operator':
+          namespace: 'kubeflow-charmers'
           repo_name: 'charm-kubeflow-pytorch-operator'
           git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
       - 'kubeflow-seldon-api-frontend':
+          namespace: 'kubeflow-charmers'
           repo_name: 'charm-kubeflow-seldon-api-frontend'
           git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
       - 'kubeflow-seldon-cluster-manager':
+          namespace: 'kubeflow-charmers'
           repo_name: 'charm-kubeflow-seldon-cluster-manager'
           git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
       - 'kubeflow-tf-hub':
+          namespace: 'kubeflow-charmers'
           repo_name: 'charm-kubeflow-tf-hub'
           git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
       - 'kubeflow-tf-job-dashboard':
+          namespace: 'kubeflow-charmers'
           repo_name: 'charm-kubeflow-tf-job-dashboard'
           git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
       - 'kubeflow-tf-job-operator':
+          namespace: 'kubeflow-charmers'
           repo_name: 'charm-kubeflow-tf-job-operator'
           git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
       - 'kubeflow-tf-serving':
+          namespace: 'kubeflow-charmers'
           repo_name: 'charm-kubeflow-tf-serving'
           git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
     jobs:

--- a/jobs/build-charms/Jenkinsfile
+++ b/jobs/build-charms/Jenkinsfile
@@ -2,6 +2,7 @@
 
 def juju_model = String.format("%s-%s", params.model, uuid())
 def charm_sh = "tox -e py36 -- python3 build-charms/charms.py"
+def cs_url = "cs:~${params.namespace}/${params.charm}"
 
 pipeline {
     agent { label 'runner-amd64' }
@@ -65,14 +66,14 @@ pipeline {
             }
             steps {
                 dir('jobs') {
-                    sh "${charm_sh} push --repo-path ${params.repo_name} --out-path ${env.JUJU_REPOSITORY}/builds/${params.charm} --charm-entity cs:~containers/${params.charm}"
+                    sh "${charm_sh} push --repo-path ${params.repo_name} --out-path ${env.JUJU_REPOSITORY}/builds/${params.charm} --charm-entity ${cs_url}"
                     script {
                         if(params.resource_build_sh) {
-                            sh "${charm_sh} resource --charm-entity cs:~containers/${params.charm} --builder ${params.repo_name}/${params.resource_build_sh} --out-path ${env.JUJU_REPOSITORY}/tmp/${params.charm} --resource-spec build-charms/resource-spec.yaml"
+                            sh "${charm_sh} resource --charm-entity ${cs_url} --builder ${params.repo_name}/${params.resource_build_sh} --out-path ${env.JUJU_REPOSITORY}/tmp/${params.charm} --resource-spec build-charms/resource-spec.yaml"
                         }
                     }
-                    sh "${charm_sh} promote --charm-entity cs:~containers/${params.charm} --from-channel unpublished --to-channel edge"
-                    sh "${charm_sh} show --charm-entity cs:~containers/${params.charm} --channel edge"
+                    sh "${charm_sh} promote --charm-entity ${cs_url} --from-channel unpublished --to-channel edge"
+                    sh "${charm_sh} show --charm-entity ${cs_url} --channel edge"
                 }
             }
         }


### PR DESCRIPTION
Kubeflow charms shouldn't get pushed to cs:~containers