### PR TITLE
Fix log_snap_versions to account for dead entities

### DIFF
--- a/jobs/integration/test_snapd_beta.py
+++ b/jobs/integration/test_snapd_beta.py
@@ -23,11 +23,12 @@ async def enable_snapd_beta_on_model(model):
 
 async def log_snap_versions(model):
     log('Logging snap versions')
-    for app in model.applications.values():
-        for unit in app.units:
-            action = await unit.run('snap list')
-            snap_versions = action.data['results']['Stdout'].strip() or 'No snaps found'
-            log(unit.name + ': ' + snap_versions)
+    for unit in model.units.values():
+        if unit.dead():
+            continue
+        action = await unit.run('snap list')
+        snap_versions = action.data['results']['Stdout'].strip() or 'No snaps found'
+        log(unit.name + ': ' + snap_versions)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Works around the error seen in https://jenkins.canonical.com/k8s/job/validate-snapd-beta/5/console

---

Please make sure to open PR's against the correct code:

- For Integration tests (test_cdk.py) please make those changes in `jobs/integration`
- For microk8s, those changes are in `jobs/build-microk8s`
- For charm builds, `jobs/build-charms`
- For bundle builds, `jobs/build-bundles`

