### PR TITLE
Ignore docker output in charm store push

### DIFF
--- a/jobs/build-charms/charms.py
+++ b/jobs/build-charms/charms.py
@@ -67,7 +67,9 @@ def push(repo_path, out_path, charm_entity):
 
     out = sh.charm.push(out_path, charm_entity, *resource_args)
     click.echo(f'Charm push returned: {out}')
-    out = yaml.load(out.stdout.decode().strip())
+    # Output includes lots of ansi escape sequences from the docker push,
+    # and we only care about the first line, which contains the url as yaml.
+    out = yaml.load(out.stdout.decode().strip().splitlines()[0])
     click.echo("Setting {} metadata: {}".format(out['url'],
                                                 git_commit))
     sh.charm.set(out['url'], 'commit={}'.format(git_commit))


### PR DESCRIPTION
Adding resources to the charm store push added in output from the docker pushing, which includes lots of control characters. We only care about the first line, so ignore the rest.

