### PR TITLE
Fixing snapd beta

### DIFF
--- a/jobs/integration/test_snapd_beta.py
+++ b/jobs/integration/test_snapd_beta.py
@@ -24,7 +24,7 @@ async def enable_snapd_beta_on_model(model):
 async def log_snap_versions(model):
     log('Logging snap versions')
     for unit in model.units.values():
-        if unit.dead():
+        if unit.dead:
             continue
         action = await unit.run('snap list')
         snap_versions = action.data['results']['Stdout'].strip() or 'No snaps found'


### PR DESCRIPTION
[Failed snapd test](https://jenkins.canonical.com/k8s/view/Validate/job/validate-snapd-beta/6/console) shows that unit.dead is a Boolean and not a function.

