### PR TITLE
Handle errors in Kubeflow charm store pushes

### DIFF
--- a/jobs/build-bundles/Jenkinsfile.kubeflow
+++ b/jobs/build-bundles/Jenkinsfile.kubeflow
@@ -18,9 +18,15 @@ pipeline {
                 git 'https://github.com/juju-solutions/bundle-kubeflow.git'
                 script {
                     // Releases bundle to defined charmstore namespace
-                    def push_cmd = "charm push . cs:~kubeflow-charmers/kubeflow | tail -n +1 | head -1 | awk '{print \$2}'"
-                    def revision = sh(script: push_cmd, returnStdout: true).trim()
-                    sh script: "charm release --channel ${params.channel} ${revision}", returnStatus: true
+                    sh '''
+                        charm push . cs:~kubeflow-charmers/kubeflow
+                        | tail -n +1
+                        | head -1
+                        | awk '{print \$2}'
+                        > stdout.txt
+                    '''
+                    def revision = readFile('stdout.txt').trim()
+                    sh "charm release --channel ${params.channel} ${revision}"
                 }
             }
         }


### PR DESCRIPTION
Jenkins pipelines won't raise an error if a shell script that has returnStatus or returnStdout fails. Write the stdout to a file instead and read it in after.