### PR TITLE
Fix broken job definition for validate-tigera-secure-ee

### DIFF
--- a/jobs/validate-tigera-secure-ee/Jenkinsfile
+++ b/jobs/validate-tigera-secure-ee/Jenkinsfile
@@ -35,11 +35,13 @@ pipeline {
                           version_overlay: params.overlay,
                           bundle_channel: params.bundle_channel,
                           disable_wait: true)
-                def license_key_file = credentials('tigera-secure-ee-license-key')
-                def registry_credentials_file = credentials('tigera-private-registry-credentials')
-                def license_key_base64 = new File(license_key_file).text.bytes.encodeBase64().toString()
-                def registry_credentials_base64 = new File(registry_credentials_file).text.bytes.encodeBase64().toString()
-                sh "juju config -m ${params.controller}:${juju_model} tigera-secure-ee license-key=${license_key_base64} registry-credentials=${registry_credentials_base64}"
+                script {
+                    def license_key_file = credentials('tigera-secure-ee-license-key')
+                    def registry_credentials_file = credentials('tigera-private-registry-credentials')
+                    def license_key_base64 = new File(license_key_file).text.bytes.encodeBase64().toString()
+                    def registry_credentials_base64 = new File(registry_credentials_file).text.bytes.encodeBase64().toString()
+                    sh "juju config -m ${params.controller}:${juju_model} tigera-secure-ee license-key=${license_key_base64} registry-credentials=${registry_credentials_base64}"
+                }
                 dir('jobs') {
                     sh "tox -e py36 -- python3 integration/tigera/disable_source_dest_check.py -m ${params.controller}:${juju_model}"
                 }


### PR DESCRIPTION
Should fix this error:
```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 38: Expected a step @ line 38, column 17.
                   def license_key_file = credentials('tigera-secure-ee-license-key')
                   ^

WorkflowScript: 39: Expected a step @ line 39, column 17.
                   def registry_credentials_file = credentials('tigera-private-registry-credentials')
                   ^

WorkflowScript: 40: Expected a step @ line 40, column 17.
                   def license_key_base64 = new File(license_key_file).text.bytes.encodeBase64().toString()
                   ^

WorkflowScript: 41: Expected a step @ line 41, column 17.
                   def registry_credentials_base64 = new File(registry_credentials_file).text.bytes.encodeBase64().toString()
                   ^

4 errors
```