### PR TITLE
Fix calico/tigera jobs leaving orphaned VPCs

### DIFF
--- a/jobs/validate-calico/Jenkinsfile
+++ b/jobs/validate-calico/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
             }
             steps {
                 sh "juju kill-controller -y ${params.controller} || true"
+                sh "tox -e py36 -- python3 integration/tigera/cleanup_vpcs.py"
                 dir('jobs') {
                     script {
                         sh "CONTROLLER=${params.controller} tox -e py36 -- python3 integration/tigera/bootstrap_aws_single_subnet.py"
@@ -70,7 +71,8 @@ pipeline {
             saveMeta()
             dir('jobs') {
                 script {
-                    sh "tox -e py36 -- bash integration/tigera/cleanup-vpc.sh"
+                    sh "juju kill-controller -y ${params.controller} || true"
+                    sh "tox -e py36 -- python3 integration/tigera/cleanup_vpcs.py"
                 }
             }
         }

--- a/jobs/validate-tigera-secure-ee/Jenkinsfile
+++ b/jobs/validate-tigera-secure-ee/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
             }
             steps {
                 sh "juju kill-controller -y ${params.controller} || true"
+                sh "tox -e py36 -- python3 integration/tigera/cleanup_vpcs.py"
                 dir('jobs') {
                     script {
                         sh "CONTROLLER=${params.controller} tox -e py36 -- python3 integration/tigera/bootstrap_aws_single_subnet.py"
@@ -77,7 +78,8 @@ pipeline {
             saveMeta()
             dir('jobs') {
                 script {
-                    sh "tox -e py36 -- bash integration/tigera/cleanup-vpc.sh"
+                    sh "juju kill-controller -y ${params.controller} || true"
+                    sh "tox -e py36 -- python3 integration/tigera/cleanup_vpcs.py"
                 }
             }
         }


### PR DESCRIPTION
Instead of having the jobs clean up the VPCs they just created, this will clean up all VPCs and related resources that are tagged `created-by=test-calico`.