### PR TITLE
Use multipass for Kubeflow testing

### DIFF
--- a/jobs/integration/test_kubeflow.py
+++ b/jobs/integration/test_kubeflow.py
@@ -81,9 +81,6 @@ async def validate_jupyterhub_api():
 def submit_tf_job(name: str):
     """Submits a TFJob to the TensorFlow Job service."""
 
-    with open(f"../tfjobs/{name}/job.yaml") as f:
-        job_def = f.read().format(mnist_image=os.environ["MNIST_IMAGE"]).encode("utf-8")
-
     output = check_output(
         [
             "microk8s.kubectl",
@@ -93,9 +90,8 @@ def submit_tf_job(name: str):
             "-n",
             os.environ["MODEL"],
             "-f",
-            "-",
-        ],
-        input=job_def,
+            f"../tfjobs/{name}/job.yaml",
+        ]
     ).strip()
 
     assert output == f"tfjob.kubeflow.org/kubeflow-{name}-test created".encode("utf-8")

--- a/jobs/validate-kubeflow-microk8s.yaml
+++ b/jobs/validate-kubeflow-microk8s.yaml
@@ -11,20 +11,14 @@
       script-path: jobs/validate-kubeflow-microk8s/Jenkinsfile
     parameters:
       - string:
-          name: model
-          default: 'validate-kubeflow-microk8s'
+          name: channel
+          default: 'stable'
       - string:
-          name: controller
-          default: 'validate-kubeflow-microk8s'
+          name: juju_channel
+          default: 'stable'
       - string:
-          name: cloud
-          default: 'jenkins-microk8s-cloud'
-      - string:
-          name: bundle_channel
-          default: 'edge'
-      - string:
-          name: bundle
-          default: 'kubeflow'
+          name: microk8s_channel
+          default: '1.13/stable'
     triggers:
         - timed: "@daily"
     properties:

--- a/jobs/validate-kubeflow-microk8s/Jenkinsfile
+++ b/jobs/validate-kubeflow-microk8s/Jenkinsfile
@@ -1,7 +1,8 @@
 @Library('juju-pipeline@master') _
 
-def juju_model = String.format("%s-%s", params.model, uuid())
-def mnist_image = String.format("mnist-test-%s", uuid())
+def exec(cmd) {
+    sh "sudo lxc exec ${lxc_name} -- bash -c 'cd /project && ${cmd}'"
+}
 
 pipeline {
     agent {
@@ -12,6 +13,8 @@ pipeline {
      */
     environment {
         PATH = "/snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin"
+        lxc_name = "validate-microk8s-${uuid()}"
+        storage_name = "validate-microk8s-${uuid()}"
     }
     options {
         ansiColor('xterm')
@@ -23,24 +26,35 @@ pipeline {
                 timeout(time: 1, unit: 'HOURS')
             }
             steps {
-                sh "juju kill-controller -y ${params.controller} || true"
                 setStartTime()
-                sh "juju bootstrap localhost ${params.controller} --debug"
+                sh "sudo lxc profile show microk8s || sudo lxc profile copy default microk8s"
+                sh "curl https://raw.githubusercontent.com/ubuntu/microk8s/master/tests/lxc/microk8s.profile | sudo lxc profile edit microk8s"
+                sh "sudo lxc launch -p default -p microk8s ubuntu:18.04 ${lxc_name}"
+                sh "sudo lxc storage create ${storage_name} dir source=/tmp/${storage_name}"
+                sh "sudo lxc storage volume create ${storage_name} storage"
+                sh "sudo lxc storage volume attach ${storage_name} storage ${lxc_name} /project"
+                exec "sudo snap install charm --classic"
+                exec "sudo snap install jq"
+                exec "sudo snap install juju --classic --channel ${params.juju_channel}"
+                exec "sudo snap install juju-wait --classic"
+                exec "sudo snap install lxd"
+                exec "sudo snap install microk8s --classic --channel ${params.microk8s_channel}"
+                exec "sudo snap install yq"
 
-                sh "microk8s.enable dns storage"
-                sh "microk8s.config | juju add-k8s ${cloud}"
-                sh "microk8s.config > kube_config"
-                sh "microk8s.docker build tfjobs/mnist/ -t ${mnist_image}"
+                exec "microk8s.enable dns storage"
+                exec "juju bootstrap lxd --debug"
+                exec "microk8s.config | juju add-k8s microk8s-cloud"
+                exec "microk8s.docker build tfjobs/mnist/ -t mnist-test:latest"
 
-                sh "juju add-model ${juju_model} ${cloud}"
-                sh "juju create-storage-pool operator-storage kubernetes storage-class=microk8s-hostpath"
-                sh "juju deploy kubeflow --channel ${params.bundle_channel}"
+                exec "juju add-model microk8s-model microk8s-cloud"
+                exec "juju create-storage-pool operator-storage kubernetes storage-class=microk8s-hostpath"
+                exec "juju deploy kubeflow --channel ${params.channel}"
 
-                sh "juju-wait -e ${params.controller}:${juju_model} -w"
+                exec "juju-wait -w"
 
-                sh "juju status | grep 'kubeflow-ambassador ' | awk '{print \$8}' > PUB_IP"
-                sh "juju config kubeflow-ambassador juju-external-hostname=localhost"
-                sh "juju expose kubeflow-ambassador"
+                exec "juju status | grep 'kubeflow-ambassador ' | awk '{print \$8}' > PUB_IP"
+                exec "juju config kubeflow-ambassador juju-external-hostname=localhost"
+                exec "juju expose kubeflow-ambassador"
             }
         }
 
@@ -51,7 +65,19 @@ pipeline {
 
             steps {
                 dir('jobs') {
-                    sh "CONTROLLER=${params.controller} MODEL=${juju_model} MNIST_IMAGE=${mnist_image} tox -e py36 -- pytest -v -s --junit-xml=validate.xml integration/test_kubeflow.py::test_validate"
+                    exec '''
+                        PY_IGNORE_IMPORTMISMATCH=1
+                        CONTROLLER=localhost
+                        MODEL=microk8s-model
+                        tox
+                            -e py36
+                            --
+                            pytest
+                                -v
+                                -s
+                                --junit-xml=validate.xml
+                                integration/test_kubeflow.py::test_validate
+                    '''.replaceAll('\\s+', ' ')
                 }
             }
         }
@@ -66,17 +92,15 @@ pipeline {
         always {
             setEndTime()
             collectDebug(params.controller, juju_model)
-
         }
         cleanup {
             sh "juju status"
             sh "juju list-controllers"
             sh "juju list-models"
             saveMeta()
-            sh "juju kill-controller -y ${params.controller} || true"
-            sh "juju remove-cloud ${cloud}"
-            sh "microk8s.docker rmi ${mnist_image}"
-
+            sh "sudo lxc storage volume detach ${storage_name} storage ${lxc_name} || true"
+            sh "sudo lxc delete --force ${lxc_name} || true"
+            sh "sudo lxc storage delete ${storage_name} || true"
         }
     }
 }

--- a/tfjobs/mnist/job.yaml
+++ b/tfjobs/mnist/job.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: "{mnist_image}"
+              image: "mnist-test:latest"
     Worker:
       replicas: 1
       restartPolicy: Never
@@ -19,4 +19,4 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: "{mnist_image}"
+              image: "mnist-test:latest"


### PR DESCRIPTION
Uses multipass to spin up a VM that is then used for testing Kubeflow. This lets us choose specific version of snap dependencies, such as microk8s.
