### PR TITLE
Replace enable-swagger-ui arg removed on v1.14

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -571,7 +571,7 @@ async def validate_extra_args(model):
             'api-extra-args': ' '.join([
                 'min-request-timeout=314',  # int arg, overrides a charm default
                 'watch-cache',              # bool arg, implied true
-                'enable-swagger-ui=false'   # bool arg, explicit false
+                'profiling=false'           # bool arg, explicit false
             ]),
             'controller-manager-extra-args': ' '.join([
                 'v=3',                        # int arg, overrides a charm default
@@ -588,7 +588,7 @@ async def validate_extra_args(model):
             'kube-apiserver': {
                 'min-request-timeout=314',
                 'watch-cache',
-                'enable-swagger-ui=false'
+                'profiling=false'
             },
             'kube-controller': {
                 'v=3',


### PR DESCRIPTION
The `enable-swagger-ui` argument we use in our tests has been [removed]([1] https://github.com/kubernetes/kubernetes/commit/9229399bd6049bc7766829b436d5cb5fe0dfe2f1) on v1.14. This PR uses the `profiling` argument instead.
