### PR TITLE
Fix Kubeflow validation kubeconfig

### DIFF
--- a/jobs/integration/test_kubeflow.py
+++ b/jobs/integration/test_kubeflow.py
@@ -92,7 +92,17 @@ def submit_tf_job(name: str):
         job_def = f.read().format(mnist_image=os.environ["MNIST_IMAGE"]).encode("utf-8")
 
     output = check_output(
-        ["microk8s.kubectl", "create", "-n", os.environ["MODEL"], "-f", "-"], input=job_def
+        [
+            "microk8s.kubectl",
+            "--kubeconfig",
+            "kube_config",
+            "create",
+            "-n",
+            os.environ["MODEL"],
+            "-f",
+            "-",
+        ],
+        input=job_def,
     ).strip()
 
     assert output == f"tfjob.kubeflow.org/kubeflow-{name}-test created".encode("utf-8")

--- a/jobs/validate-kubeflow-microk8s/Jenkinsfile
+++ b/jobs/validate-kubeflow-microk8s/Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
 
                 sh "microk8s.enable dns storage"
                 sh "microk8s.config | juju add-k8s ${cloud}"
+                sh "microk8s.config > kube_config"
                 sh "microk8s.docker build tfjobs/mnist/ -t ${mnist_image}"
 
                 sh "juju add-model ${juju_model} ${cloud}"


### PR DESCRIPTION
AWS needs to be pointed at the right kube_config file, and microk8s can point at the same file if it's created in the Jenkinsfile.
