### PR TITLE
Fix kube_config path

### DIFF
--- a/jobs/integration/test_kubeflow.py
+++ b/jobs/integration/test_kubeflow.py
@@ -95,7 +95,7 @@ def submit_tf_job(name: str):
         [
             "microk8s.kubectl",
             "--kubeconfig",
-            "kube_config",
+            "../kube_config",
             "create",
             "-n",
             os.environ["MODEL"],


### PR DESCRIPTION
It gets put in the repo root directory, and the test script is run from jobs/.
