### PR TITLE
Use PUB_IP for calculating Ambassador IP

### DIFF
--- a/jobs/validate-kubeflow-microk8s/Jenkinsfile
+++ b/jobs/validate-kubeflow-microk8s/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
 
                 sh "juju-wait -e ${params.controller}:${juju_model} -w"
 
+                sh "juju status | grep 'kubeflow-ambassador ' | awk '{print \$8}' > PUB_IP"
                 sh "juju config kubeflow-ambassador juju-external-hostname=localhost"
                 sh "juju expose kubeflow-ambassador"
             }


### PR DESCRIPTION
The Jenkinsfile wrapper will calculate the appropriate Ambassador IP, and the test script will expect a file called PUB_IP to be created with the appropriate IP.

