### PR TITLE
Publish redis-k8s charm to kubeflow-charmers namespace

### DIFF
--- a/jobs/build-charms.yaml
+++ b/jobs/build-charms.yaml
@@ -141,6 +141,10 @@
           namespace: 'kubeflow-charmers'
           repo_name: 'charm-kubeflow-tf-serving'
           git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
+      - 'redis-k8s':
+          namespace: 'kubeflow-charmers'
+          repo_name: 'charm-redis-k8s'
+          git_repo: 'https://github.com/juju-solutions/{repo_name}.git'
     jobs:
       - '{name}-{charm}'
 

--- a/jobs/build-charms/promote.groovy
+++ b/jobs/build-charms/promote.groovy
@@ -29,6 +29,7 @@ def charms = [
     'kubeflow-charmers/kubeflow-tf-job-dashboard',
     'kubeflow-charmers/kubeflow-tf-job-operator',
     'kubeflow-charmers/kubeflow-tf-serving',
+    'kubeflow-charmers/redis-k8s',
 ]
 
 pipeline {

--- a/jobs/release-charm.yaml
+++ b/jobs/release-charm.yaml
@@ -45,6 +45,7 @@
             - 'kubeflow-charmers/kubeflow-tf-job-dashboard'
             - 'kubeflow-charmers/kubeflow-tf-job-operator'
             - 'kubeflow-charmers/kubeflow-tf-serving'
+            - 'kubeflow-charmers/redis-k8s'
     properties:
       - build-discarder:
           num-to-keep: 2


### PR DESCRIPTION
In order to support the seldon kubeflow charms.