### PR TITLE
Add charmed-kubernetes bundle to release-charm, promote jobs

### DIFF
--- a/jobs/build-charms/promote.groovy
+++ b/jobs/build-charms/promote.groovy
@@ -15,6 +15,7 @@ def charms = [
     'containers/keepalived',
     'containers/docker-registry',
     'containers/tigera-secure-ee',
+    'containers/bundle/charmed-kubernetes',
     'containers/bundle/canonical-kubernetes',
     'containers/bundle/kubernetes-core',
     'containers/bundle/kubernetes-calico',

--- a/jobs/release-charm.yaml
+++ b/jobs/release-charm.yaml
@@ -31,6 +31,7 @@
             - 'containers/kubernetes-master'
             - 'containers/kubernetes-worker'
             - 'containers/tigera-secure-ee'
+            - 'containers/charmed-kubernetes'
             - 'containers/canonical-kubernetes'
             - 'containers/kubernetes-core'
             - 'containers/kubernetes-calico'


### PR DESCRIPTION
As a follow up to https://github.com/juju-solutions/kubernetes-jenkins/commit/4f3bada8eb9f1a24558b4a3e44b146496b85682c, we also need to add the new bundle to the release-charm and promote jobs.