### PR TITLE
dump iptables at the end of validate-alt-arch

### DIFF
--- a/jobs/validate-alt-arch/Jenkinsfile
+++ b/jobs/validate-alt-arch/Jenkinsfile
@@ -98,6 +98,8 @@ pipeline {
         always {
             setEndTime()
             sh "sudo lxc profile show default"
+            sh "sudo iptables -n -L"
+            sh "sudo iptables -n -L -t nat"
             collectDebug(params.controller,
                          juju_model)
 


### PR DESCRIPTION
Alt arches test with LXD, which can be problematic if iptables interferes with container connectivity. Dump iptables rules during post to help determine if rules are be to blame for failures.