### PR TITLE
dump iptables before deploy to check host firewall

### DIFF
--- a/jobs/validate-alt-arch/Jenkinsfile
+++ b/jobs/validate-alt-arch/Jenkinsfile
@@ -48,6 +48,8 @@ pipeline {
                 sh "juju bootstrap ${params.cloud} ${params.controller} --debug"
                 sh "juju add-model -c ${params.controller} ${juju_model}"
                 sh "cat jobs/validate-alt-arch/lxd-profile.yaml | sed -e \"s/##MODEL##/${juju_model}/\" | sudo lxc profile edit juju-${juju_model}"
+                sh "sudo iptables -n -L"
+                sh "sudo iptables -n -L -t nat"
                 setStartTime()
                 deployCDK(controller: params.controller,
                           model: juju_model,


### PR DESCRIPTION
#350 showed us that iptables were causing lxd issues when validating lxd deployments on alt arches.  This will show us the state of the lxd host firewall *before* deployment so we can see if there's something in the tests that alters iptables.