### PR TITLE
Attempt to fix error in disable_source_dest_check during json.loads

### DIFF
--- a/jobs/integration/tigera/disable_source_dest_check.py
+++ b/jobs/integration/tigera/disable_source_dest_check.py
@@ -20,7 +20,7 @@ def get_juju_status():
         '--format', 'json',
         '-m', MODEL
     ]
-    output = check_output(cmd)
+    output = check_output(cmd, encoding='UTF-8')
     status = json.loads(output)
     return status
 


### PR DESCRIPTION
Here's a hopeful quick fix. I can't repro this locally, so I can't verify.

Here's the stacktrace:
```
Traceback (most recent call last):
  File "/var/lib/jenkins/slaves/jenkins-slave-6/workspace/validate-v1.14.x-canonical-kubernetes/jobs/integration/tigera/disable_source_dest_check.py", line 83, in <module>
    main()
  File "/var/lib/jenkins/slaves/jenkins-slave-6/workspace/validate-v1.14.x-canonical-kubernetes/jobs/integration/tigera/disable_source_dest_check.py", line 66, in main
    status = get_juju_status()
  File "/var/lib/jenkins/slaves/jenkins-slave-6/workspace/validate-v1.14.x-canonical-kubernetes/jobs/integration/tigera/disable_source_dest_check.py", line 24, in get_juju_status
    status = json.loads(output)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```