### PR TITLE
alt arches should use localhost overlays

### DIFF
--- a/jobs/includes/k8s-localhost-support-matrix.inc
+++ b/jobs/includes/k8s-localhost-support-matrix.inc
@@ -1,0 +1,9 @@
+- 'v1.13.x':
+    version_overlay: 'jobs/overlays/1.13-edge-localhost-overlay.yaml'
+    snap_channel: '1.13/edge'
+- 'v1.14.x':
+    version_overlay: 'jobs/overlays/1.14-edge-localhost-overlay.yaml'
+    snap_channel: '1.14/edge'
+- 'v1.15.x':
+    version_overlay: 'jobs/overlays/1.15-edge-localhost-overlay.yaml'
+    snap_channel: '1.15/edge'

--- a/jobs/validate-alt-arch.yaml
+++ b/jobs/validate-alt-arch.yaml
@@ -54,7 +54,7 @@
 - alt_version_defaults: &alt_version_defaults
     name: 'alt-version-defaults'
     version:
-      !include: includes/k8s-support-matrix.inc
+      !include: includes/k8s-localhost-support-matrix.inc
 
 - job-template:
     name: 'validate-alt-{arch}-{version}-{bundle}'


### PR DESCRIPTION
Overlays for localhost were updated in #358.  Make the validate-alt jobs (which are always LXD) use those by default.