### PR TITLE
pin pynacl to 1.1.2, the latest version compatible with pymacaroons and alt arches

### DIFF
--- a/jobs/requirements.txt
+++ b/jobs/requirements.txt
@@ -26,3 +26,4 @@ setuptools
 sh
 staticjinja
 pyyaml==3.13
+pynacl==1.1.2


### PR DESCRIPTION
Tests require pymacaroons, which requires PyNaCl >= 1.1.2 < 2.0.0.  Recent versions of pynacl, specifically 1.2.0, 1.2.1, and 1.3.0 fail to install on our alt arches with errors similar to these:

https://github.com/jedisct1/libsodium/issues/721
https://github.com/jedisct1/libsodium/issues/749