### PR TITLE
use utils.scp_to() for localhost workaround

### DIFF
--- a/jobs/integration/validation.py
+++ b/jobs/integration/validation.py
@@ -1512,7 +1512,7 @@ async def validate_dns_provider(model):
         yaml.dump(pod_def, f)
         f.flush()
         remote_path = '/tmp/validate-dns-provider-ubuntu.yaml'
-        await master_unit.scp_to(f.name, remote_path)
+        await scp_to(f.name, master_unit, remote_path)
         cmd = '/snap/bin/kubectl apply -f ' + remote_path
         await run_until_success(master_unit, cmd)
 


### PR DESCRIPTION
In a lxd cloud, `unit.scp_to` has trouble figuring out the address (often choosing the flannel interface vs eth0, for example). We work around this in other validation cases with `utils.scp_to`, which uses the unit name vs address in the scp invocation.

Looks like we missed this when coredns validation tests were included. Let's fix that post haste!