### PR TITLE
Keep Kubeflow validation jobs around for a week

### DIFF
--- a/jobs/validate-kubeflow-aws.yaml
+++ b/jobs/validate-kubeflow-aws.yaml
@@ -20,7 +20,7 @@
         - timed: "@daily"
     properties:
       - build-discarder:
-          num-to-keep: 2
+          days-to-keep: 7
 
 - project:
     name: validate-kubeflow-aws

--- a/jobs/validate-kubeflow-microk8s.yaml
+++ b/jobs/validate-kubeflow-microk8s.yaml
@@ -23,7 +23,7 @@
         - timed: "@daily"
     properties:
       - build-discarder:
-          num-to-keep: 2
+          days-to-keep: 7
 
 - project:
     name: validate-kubeflow-microk8s


### PR DESCRIPTION
So that old builds will survive a weekend with timed builds, in case there's context from Friday.

