### PR TITLE
update conformance job with required lxd/bad-arch changes

### DIFF
--- a/jobs/cncf-conformance/Jenkinsfile
+++ b/jobs/cncf-conformance/Jenkinsfile
@@ -19,13 +19,51 @@ pipeline {
     }
 
     stages {
+        stage("Prep") {
+            steps {
+                sh "juju kill-controller -y ${juju_controller} || true"
+            }
+        }
         stage("Deploy") {
             options {
                 timeout(time: 4, unit: 'HOURS')
             }
             steps {
-                sh "juju kill-controller -y ${juju_controller} || true"
+                script {
+                    def arch = sh(
+                        script:"arch",
+                        returnStdout: true
+                    ).trim()
+                    def bad_arches = ['s390x', 'aarch64', 'arm64']
+                    if(bad_arches.contains(arch)) {
+                        echo "Updating overlay b/c of ${arch}"
+                        def data = readYaml file: params.version_overlay
+                        data['applications']['kubernetes-worker'].options.ingress = false
+                        data['applications']['kubernetes-master']['options']['enable-metrics'] = false
+                        data['applications']['kubernetes-master']['options']['enable-dashboard-addons'] = false
+                        sh "rm ${params.version_overlay}"
+                        writeYaml file: params.version_overlay, data: data
+                        sh '''
+                            echo "Ensure pre-existing K8s iptables rules are removed"
+                            sudo iptables -F
+                            sudo iptables -t mangle -F
+                            sudo iptables -t nat -F
+                            sudo iptables -X
+                            echo "Restarting docker and lxd to recreate required iptables rules"
+                            sudo systemctl restart docker.service
+                            sudo systemctl restart snap.lxd.daemon.service
+                            echo "Listing pre-deployment iptables rules"
+                            sudo iptables -n -L
+                            sudo iptables -n -L -t mangle
+                            sudo iptables -n -L -t nat
+                        '''
+                        sh "cat jobs/validate-alt-arch/lxd-profile.yaml | sed -e \"s/##MODEL##/${juju_model}/\" | sudo lxc profile edit juju-${juju_model}"
+                    }
+                    sh "cat ${params.version_overlay}"
+                }
+
                 sh "juju bootstrap ${params.cloud} ${juju_controller} --debug"
+                sh "juju add-model -c ${juju_controller} ${juju_model}"
                 setStartTime()
                 deployCDK(controller: juju_controller,
                           model: juju_model,
@@ -76,6 +114,12 @@ pipeline {
         }
         always {
             setEndTime()
+            sh '''
+                echo "Listing post-deployment iptables rules"
+                sudo iptables -n -L
+                sudo iptables -n -L -t mangle
+                sudo iptables -n -L -t nat
+            '''
             collectDebug(juju_controller,
                          juju_model)
         }


### PR DESCRIPTION
Non-Intel arches deploy to LXD, which requires a few changes in the test environment.  This PR is inspired by `./jobs/validate-alt-arch/Jenkinsfile`.