### PR TITLE
make model available earlier

### DIFF
--- a/jobs/cncf-conformance/Jenkinsfile
+++ b/jobs/cncf-conformance/Jenkinsfile
@@ -29,6 +29,10 @@ pipeline {
                 timeout(time: 4, unit: 'HOURS')
             }
             steps {
+                sh "juju bootstrap ${params.cloud} ${juju_controller} --debug"
+                sh "juju add-model -c ${juju_controller} ${juju_model}"
+                setStartTime()
+
                 script {
                     def arch = sh(
                         script:"arch",
@@ -62,9 +66,6 @@ pipeline {
                     sh "cat ${params.version_overlay}"
                 }
 
-                sh "juju bootstrap ${params.cloud} ${juju_controller} --debug"
-                sh "juju add-model -c ${juju_controller} ${juju_model}"
-                setStartTime()
                 deployCDK(controller: juju_controller,
                           model: juju_model,
                           bundle: "cs:~containers/${params.bundle}",


### PR DESCRIPTION
Move the bootstrap/add-model earlier so we can apply lxc profile edits if running on an alt arch.